### PR TITLE
Add MPT (Multi-Purpose Token) support to tokens and txmeta packages

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -7,6 +7,8 @@
 		"@xrplkit/book": "file:../book",
 		"@xrplkit/simulate": "file:../simulate",
 		"@xrplkit/socket": "file:../socket",
+		"@xrplkit/tokens": "file:../tokens",
+		"@xrplkit/txmeta": "file:../txmeta",
 		"@xrplkit/xfl": "file:../xfl",
 		"@xrplkit/xls26": "file:../xls26",
 		"@xrplkit/xls89": "file:../xls89"

--- a/tests/tokens/tokens.test.js
+++ b/tests/tokens/tokens.test.js
@@ -1,0 +1,135 @@
+import { expect } from 'chai'
+import { amountFromRippled, amountToRippled, tokenFromAmount, isSameToken } from '@xrplkit/tokens'
+
+describe('amountFromRippled', () => {
+	it('should return undefined for undefined', () => {
+		expect(amountFromRippled(undefined)).to.equal(undefined)
+	})
+
+	it('should parse XRP drops string', () => {
+		let result = amountFromRippled('10000000')
+		expect(result.currency).to.equal('XRP')
+		expect(result.value.toString()).to.equal('10')
+	})
+
+	it('should parse IOU object', () => {
+		let result = amountFromRippled({ currency: 'USD', issuer: 'rXxx', value: '100' })
+		expect(result.currency).to.equal('USD')
+		expect(result.issuer).to.equal('rXxx')
+		expect(result.value.toString()).to.equal('100')
+	})
+
+	it('should parse MPT object', () => {
+		let result = amountFromRippled({ mpt_issuance_id: '0000ABC123', value: '500' })
+		expect(result.mpt_issuance_id).to.equal('0000ABC123')
+		expect(result.currency).to.equal(undefined)
+		expect(result.issuer).to.equal(undefined)
+		expect(result.value.toString()).to.equal('500')
+	})
+})
+
+describe('amountToRippled', () => {
+	it('should return undefined for undefined', () => {
+		expect(amountToRippled(undefined)).to.equal(undefined)
+	})
+
+	it('should convert XRP to drops string', () => {
+		expect(amountToRippled({ currency: 'XRP', value: '10' })).to.equal('10000000')
+	})
+
+	it('should convert IOU', () => {
+		let result = amountToRippled({ currency: 'USD', issuer: 'rXxx', value: '100' })
+		expect(result.value).to.equal('100')
+		expect(result.issuer).to.equal('rXxx')
+		expect(result.currency).to.equal('USD')
+	})
+
+	it('should convert MPT', () => {
+		let result = amountToRippled({ mpt_issuance_id: '0000ABC123', value: '500' })
+		expect(result.mpt_issuance_id).to.equal('0000ABC123')
+		expect(result.value).to.equal('500')
+		expect(result.currency).to.equal(undefined)
+	})
+})
+
+describe('tokenFromAmount', () => {
+	it('should return undefined for undefined', () => {
+		expect(tokenFromAmount(undefined)).to.equal(undefined)
+	})
+
+	it('should extract IOU token', () => {
+		let result = tokenFromAmount({ currency: 'USD', issuer: 'rXxx', value: '100' })
+		expect(result.currency).to.equal('USD')
+		expect(result.issuer).to.equal('rXxx')
+		expect(result.mpt_issuance_id).to.equal(undefined)
+	})
+
+	it('should extract MPT token', () => {
+		let result = tokenFromAmount({ mpt_issuance_id: '0000ABC123', value: '500' })
+		expect(result.mpt_issuance_id).to.equal('0000ABC123')
+		expect(result.currency).to.equal(undefined)
+		expect(result.issuer).to.equal(undefined)
+	})
+})
+
+describe('isSameToken', () => {
+	it('should match two XRP strings', () => {
+		expect(isSameToken('XRP', 'XRP')).to.equal(true)
+	})
+
+	it('should match same IOU', () => {
+		expect(isSameToken(
+			{ currency: 'USD', issuer: 'rXxx' },
+			{ currency: 'USD', issuer: 'rXxx' }
+		)).to.equal(true)
+	})
+
+	it('should not match different IOU issuer', () => {
+		expect(isSameToken(
+			{ currency: 'USD', issuer: 'rXxx' },
+			{ currency: 'USD', issuer: 'rYyy' }
+		)).to.equal(false)
+	})
+
+	it('should not match different IOU currency', () => {
+		expect(isSameToken(
+			{ currency: 'USD', issuer: 'rXxx' },
+			{ currency: 'EUR', issuer: 'rXxx' }
+		)).to.equal(false)
+	})
+
+	it('should match same MPT', () => {
+		expect(isSameToken(
+			{ mpt_issuance_id: '0000ABC123' },
+			{ mpt_issuance_id: '0000ABC123' }
+		)).to.equal(true)
+	})
+
+	it('should not match different MPT', () => {
+		expect(isSameToken(
+			{ mpt_issuance_id: '0000ABC123' },
+			{ mpt_issuance_id: '0000DEF456' }
+		)).to.equal(false)
+	})
+
+	it('should not match MPT vs IOU', () => {
+		expect(isSameToken(
+			{ mpt_issuance_id: '0000ABC123' },
+			{ currency: 'USD', issuer: 'rXxx' }
+		)).to.equal(false)
+	})
+
+	it('should not match MPT vs XRP', () => {
+		expect(isSameToken(
+			{ mpt_issuance_id: '0000ABC123' },
+			'XRP'
+		)).to.equal(false)
+	})
+
+	it('should not match IOU vs XRP', () => {
+		expect(isSameToken(
+			{ currency: 'USD', issuer: 'rXxx' },
+			'XRP'
+		)).to.equal(false)
+	})
+})

--- a/tests/txmeta/fixtures/iou-iou-amm-offer.json
+++ b/tests/txmeta/fixtures/iou-iou-amm-offer.json
@@ -1,0 +1,214 @@
+{
+  "description": "IOU/IOU AMM non-consumption: offer does NOT cross",
+  "tx": {
+    "Account": "rGCpCmQ8wLmd5houaHsY4JeXKyyVNJV8Fy",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 17433,
+    "Sequence": 17405,
+    "SigningPubKey": "EDEFC0C0D3C85BAB39F622EE833E5F875C03932D18E6D91503787779FDD082D5F5",
+    "TakerGets": {
+      "currency": "EUR",
+      "issuer": "rKDV2P6ZafrdDD5j3et9SKJWQRLfTc74hq",
+      "value": "75"
+    },
+    "TakerPays": {
+      "currency": "USD",
+      "issuer": "rn8gAZyXqdDdE9fB9WKgK8am3vFUV8ygfK",
+      "value": "50"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "1B27758EE68F56FD181635ADAF3FF41A3B8F46E0E670D4BE175C0D65444245EF23A3EBE1C08297FF31F84D5FC9C2E1AC742CAC67956696767D8688137099990B",
+    "hash": "7638F485521F016B092A1BB035B47E35DFB7EE7B01B7A45F1CFFC332BB93039B",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rGCpCmQ8wLmd5houaHsY4JeXKyyVNJV8Fy",
+              "RootIndex": "01DEF58B6EEDCD4BA7D0C053A6D6889B77D7C8866785DE2003B60BAD5891EC5E"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "01DEF58B6EEDCD4BA7D0C053A6D6889B77D7C8866785DE2003B60BAD5891EC5E",
+            "PreviousTxnID": "91ADA48DFFC2449FD82EBE748321C4494FE031180E823C10DE6545B7BC5A3959",
+            "PreviousTxnLgrSeq": 17409
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rGCpCmQ8wLmd5houaHsY4JeXKyyVNJV8Fy",
+              "Balance": "999999976",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 17406
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "1B4B56BFB145DD899ACE0989A8EA22684DAC1AC87DB4011BC93E047984A1D4BD",
+            "PreviousFields": {
+              "Balance": "999999988",
+              "OwnerCount": 1,
+              "Sequence": 17405
+            },
+            "PreviousTxnID": "91ADA48DFFC2449FD82EBE748321C4494FE031180E823C10DE6545B7BC5A3959",
+            "PreviousTxnLgrSeq": 17409
+          }
+        },
+        {
+          "CreatedNode": {
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "2AD2885997D19D0A629966C6CCAB801BD8A098E9CB297361C12AF9FA0D43D432",
+            "NewFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "-50"
+              },
+              "Flags": 2228224,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rGCpCmQ8wLmd5houaHsY4JeXKyyVNJV8Fy",
+                "value": "0"
+              },
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "rn8gAZyXqdDdE9fB9WKgK8am3vFUV8ygfK",
+                "value": "0"
+              }
+            }
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "EUR",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "944.4444444444444"
+              },
+              "Flags": 65536,
+              "HighLimit": {
+                "currency": "EUR",
+                "issuer": "rKDV2P6ZafrdDD5j3et9SKJWQRLfTc74hq",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "EUR",
+                "issuer": "rGCpCmQ8wLmd5houaHsY4JeXKyyVNJV8Fy",
+                "value": "10000"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "34390BF121E3ED34EF66E6C0A6D9AA5B5E3237AEA217DDBBD3127C73B15A29E4",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "EUR",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "1000"
+              }
+            },
+            "PreviousTxnID": "88F28D2BC6975B39C7E7EF7611C70EC54770B58AAB5115D16394CACC440F48D8",
+            "PreviousTxnLgrSeq": 17412
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "EUR",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "555.5555555555556"
+              },
+              "Flags": 16842752,
+              "HighLimit": {
+                "currency": "EUR",
+                "issuer": "rKDV2P6ZafrdDD5j3et9SKJWQRLfTc74hq",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "EUR",
+                "issuer": "rfoqTyqa87FST99gK8GnCMQ7EaHGn7Fpjf",
+                "value": "0"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "561CE0571579FDF394603186F161F1C542B9EC62F7C264DE2D6B74229723604F",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "EUR",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "500"
+              }
+            },
+            "PreviousTxnID": "200B70868F59F3F6C1D61376191ACB19F6ABF0BE7473A5C107112EBC84A61DFE",
+            "PreviousTxnLgrSeq": 17413
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rn8gAZyXqdDdE9fB9WKgK8am3vFUV8ygfK",
+              "RootIndex": "8BA3FA853327A638DCEF5B4565847CDC95A7C4FBA045016A5A95D14D95A2DBA7"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "8BA3FA853327A638DCEF5B4565847CDC95A7C4FBA045016A5A95D14D95A2DBA7",
+            "PreviousTxnID": "200B70868F59F3F6C1D61376191ACB19F6ABF0BE7473A5C107112EBC84A61DFE",
+            "PreviousTxnLgrSeq": 17413
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "-450"
+              },
+              "Flags": 16908288,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rfoqTyqa87FST99gK8GnCMQ7EaHGn7Fpjf",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "rn8gAZyXqdDdE9fB9WKgK8am3vFUV8ygfK",
+                "value": "0"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "CD01AEA7742818EAB039B7D7139116F82982FA8DFA18FCA89C9ED5DDDF219FF0",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "-500"
+              }
+            },
+            "PreviousTxnID": "200B70868F59F3F6C1D61376191ACB19F6ABF0BE7473A5C107112EBC84A61DFE",
+            "PreviousTxnLgrSeq": 17413
+          }
+        },
+        {
+          "ModifiedNode": {
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "EE226E498DC847FE1C1E6D4C1529C058FA60D07185C14055E3692B367BE8EA70",
+            "PreviousTxnID": "200B70868F59F3F6C1D61376191ACB19F6ABF0BE7473A5C107112EBC84A61DFE",
+            "PreviousTxnLgrSeq": 17413
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": []
+}

--- a/tests/txmeta/fixtures/iou-iou-offer.json
+++ b/tests/txmeta/fixtures/iou-iou-offer.json
@@ -1,0 +1,293 @@
+{
+  "description": "IOU/IOU exact offer match: 200 EUR for 100 USD",
+  "tx": {
+    "Account": "r9dtnYBTRxZ4cFrsrij1uGN96bVzXSMWLn",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 12618,
+    "Sequence": 12591,
+    "SigningPubKey": "ED2C46BA228273326AE2BE9019C533E909BCB9A083460D0913948370D8B8AACEFA",
+    "TakerGets": {
+      "currency": "EUR",
+      "issuer": "rD7qHYFE8fcm7LhiMrPwL1jPXFU39ABuVf",
+      "value": "200"
+    },
+    "TakerPays": {
+      "currency": "USD",
+      "issuer": "rBgFsoTWkEtkg8uA97XCrhPLPXrkzRuRbJ",
+      "value": "100"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "9C9221090038EF3B163AC3585D78DEB7090D8B23732254EDA3723CF55D7B95913386795DD3749338E6C7D310F51B6921B7390D25F0EF4CE6C9D14C7FEBDF810D",
+    "hash": "242BD65F7E023DC57D076A6D1C96D93275158AE71CD6600F438D786D8555C7AA",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "900"
+              },
+              "Flags": 65536,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rBgFsoTWkEtkg8uA97XCrhPLPXrkzRuRbJ",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "r3LoxWETnFpt8uW7WVMQKs8azrpD779aJ2",
+                "value": "10000"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "7F8C30DB744928F8A2BFD3AA250F4B1102E4A25EA6EA294F1E113D862F197F5B",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "1000"
+              }
+            },
+            "PreviousTxnID": "9DE7730C6008246DD9559F166ABCD92FEB5B81FC9DBF613FD3119FA514272FB5",
+            "PreviousTxnLgrSeq": 12596
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "EUR",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "800"
+              },
+              "Flags": 65536,
+              "HighLimit": {
+                "currency": "EUR",
+                "issuer": "rD7qHYFE8fcm7LhiMrPwL1jPXFU39ABuVf",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "EUR",
+                "issuer": "r9dtnYBTRxZ4cFrsrij1uGN96bVzXSMWLn",
+                "value": "10000"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "84D12239A8EF682FE68E1457210599D9668282A5C2010FED0D3430A7015C0593",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "EUR",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "1000"
+              }
+            },
+            "PreviousTxnID": "C7015FD17EACAB39BEF4B11C455B6A31E3C07E6172081C9D9740846AD52EEE40",
+            "PreviousTxnLgrSeq": 12597
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "r9dtnYBTRxZ4cFrsrij1uGN96bVzXSMWLn",
+              "Balance": "399999964",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 12592
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "919E559FEE5F06C9E13B72D728450D2D775EA8119F8E92B18E1B58551E255D0F",
+            "PreviousFields": {
+              "Balance": "399999976",
+              "Sequence": 12591
+            },
+            "PreviousTxnID": "9E850705F6832D789299949D5B0F61C69B303B6918165D629F6EDA8CA0F85DA2",
+            "PreviousTxnLgrSeq": 12595
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "Account": "r3LoxWETnFpt8uW7WVMQKs8azrpD779aJ2",
+              "BookDirectory": "A7DD47C7EEC2428FE5E41DC7BF2A8C600F1DC0FC0CCBBE8655071AFD498D0000",
+              "BookNode": "0",
+              "Flags": 0,
+              "OwnerNode": "0",
+              "PreviousTxnID": "C46D35F6B17DF042D3C44606E3A9A4BA767BC0284E70DE3E08BBB3D5F79CC01E",
+              "PreviousTxnLgrSeq": 12598,
+              "Sequence": 12590,
+              "TakerGets": {
+                "currency": "USD",
+                "issuer": "rBgFsoTWkEtkg8uA97XCrhPLPXrkzRuRbJ",
+                "value": "0"
+              },
+              "TakerPays": {
+                "currency": "EUR",
+                "issuer": "rD7qHYFE8fcm7LhiMrPwL1jPXFU39ABuVf",
+                "value": "0"
+              }
+            },
+            "LedgerEntryType": "Offer",
+            "LedgerIndex": "A442B2645AAE378A15EDC6AA982EA4D7EFB7C2C8C515086F0C6AF012616CFEDB",
+            "PreviousFields": {
+              "TakerGets": {
+                "currency": "USD",
+                "issuer": "rBgFsoTWkEtkg8uA97XCrhPLPXrkzRuRbJ",
+                "value": "100"
+              },
+              "TakerPays": {
+                "currency": "EUR",
+                "issuer": "rD7qHYFE8fcm7LhiMrPwL1jPXFU39ABuVf",
+                "value": "200"
+              }
+            }
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "ExchangeRate": "55071afd498d0000",
+              "Flags": 0,
+              "PreviousTxnID": "C46D35F6B17DF042D3C44606E3A9A4BA767BC0284E70DE3E08BBB3D5F79CC01E",
+              "PreviousTxnLgrSeq": 12598,
+              "RootIndex": "A7DD47C7EEC2428FE5E41DC7BF2A8C600F1DC0FC0CCBBE8655071AFD498D0000",
+              "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+              "TakerGetsIssuer": "7538C118CBA91187E42343C959EA01C0909E460A",
+              "TakerPaysCurrency": "0000000000000000000000004555520000000000",
+              "TakerPaysIssuer": "88E50C0381F107EA80A6D74DF7DDFCB781665FF8"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "A7DD47C7EEC2428FE5E41DC7BF2A8C600F1DC0FC0CCBBE8655071AFD498D0000"
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "r3LoxWETnFpt8uW7WVMQKs8azrpD779aJ2",
+              "RootIndex": "C0C34D04A2B22DC6BDC47A604851C8146C104E9349BFE057E2746698A86E61B3"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "C0C34D04A2B22DC6BDC47A604851C8146C104E9349BFE057E2746698A86E61B3",
+            "PreviousTxnID": "C46D35F6B17DF042D3C44606E3A9A4BA767BC0284E70DE3E08BBB3D5F79CC01E",
+            "PreviousTxnLgrSeq": 12598
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "r3LoxWETnFpt8uW7WVMQKs8azrpD779aJ2",
+              "Balance": "399999964",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 12591
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "C5C15C6709BD898924931F071C9A8E5378F1C196DDD941802CB9727D58A43A0E",
+            "PreviousFields": {
+              "OwnerCount": 3
+            },
+            "PreviousTxnID": "C46D35F6B17DF042D3C44606E3A9A4BA767BC0284E70DE3E08BBB3D5F79CC01E",
+            "PreviousTxnLgrSeq": 12598
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "EUR",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "200"
+              },
+              "Flags": 65536,
+              "HighLimit": {
+                "currency": "EUR",
+                "issuer": "rD7qHYFE8fcm7LhiMrPwL1jPXFU39ABuVf",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "EUR",
+                "issuer": "r3LoxWETnFpt8uW7WVMQKs8azrpD779aJ2",
+                "value": "10000"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "CBE914C17276BBA4A7AF8C8941B007A30C7D90F01C1ABC2C4612591F77AFA4CF",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "EUR",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "0"
+              }
+            },
+            "PreviousTxnID": "6E72E1E8903E20A5AFA97D5DC0E2B5D2FDC5F462B015699BD98A776FD6F35428",
+            "PreviousTxnLgrSeq": 12593
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "100"
+              },
+              "Flags": 65536,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rBgFsoTWkEtkg8uA97XCrhPLPXrkzRuRbJ",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "r9dtnYBTRxZ4cFrsrij1uGN96bVzXSMWLn",
+                "value": "10000"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "FA57647320450F55ABDCBC18A564F6070D0842B860BA507B38CAC40C3D342BD6",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "0"
+              }
+            },
+            "PreviousTxnID": "05B6950FBB04481153572007B0993837501F3F77380FA0D8D5EFEBD1DA165EF9",
+            "PreviousTxnLgrSeq": 12594
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": [
+    {
+      "hash": "242BD65F7E023DC57D076A6D1C96D93275158AE71CD6600F438D786D8555C7AA",
+      "maker": "r3LoxWETnFpt8uW7WVMQKs8azrpD779aJ2",
+      "taker": "r9dtnYBTRxZ4cFrsrij1uGN96bVzXSMWLn",
+      "sequence": 12590,
+      "takerPaid": {
+        "currency": "EUR",
+        "issuer": "rD7qHYFE8fcm7LhiMrPwL1jPXFU39ABuVf",
+        "value": "200"
+      },
+      "takerGot": {
+        "currency": "USD",
+        "issuer": "rBgFsoTWkEtkg8uA97XCrhPLPXrkzRuRbJ",
+        "value": "100"
+      }
+    }
+  ]
+}

--- a/tests/txmeta/fixtures/iou-mpt-amm-offer.json
+++ b/tests/txmeta/fixtures/iou-mpt-amm-offer.json
@@ -1,0 +1,96 @@
+{
+  "description": "IOU/MPT AMM non-consumption: offer does NOT cross",
+  "tx": {
+    "Account": "rDgCWku5EvbfnZFFD8kFzxuzpZRJTZbmHY",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 17448,
+    "Sequence": 17420,
+    "SigningPubKey": "EDA1E31E04435BAA7B0A38EC4C483582E32421CB5A7D482580D750AE1E678102E6",
+    "TakerGets": {
+      "mpt_issuance_id": "0000440975FFB7DF5FA61340D0E8BECC77E33A1C30C3399F",
+      "value": "50000"
+    },
+    "TakerPays": {
+      "currency": "USD",
+      "issuer": "rsjpuu4SVse7ZUXdQ2BiL6on83QVVacz7K",
+      "value": "50"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "0795E4EB62E07F2711755F7FF844CD77B878FF3CA941A5BC130C4779AD7C51E8681E8001A3ADF12D3B0D7DDF22EC6A2ED4F37B12ADD27BF9FF40710D1F4F5C0B",
+    "hash": "F8EFA539DF1E855FAF5AA02FB60164C086B5DC6840EC4713D02F0649BE0A0717",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rDgCWku5EvbfnZFFD8kFzxuzpZRJTZbmHY",
+              "Balance": "999999976",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 17421
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "80CBA09202A76FCFF6FF3F8660522E543F0CFF188ABA009152D87354FA9481A4",
+            "PreviousFields": {
+              "Balance": "999999988",
+              "OwnerCount": 1,
+              "Sequence": 17420
+            },
+            "PreviousTxnID": "E5F210752E3F2D8A3D1CDBFA6D413EF07178D3C7F49D15B6D08F8387D5B3FF96",
+            "PreviousTxnLgrSeq": 17424
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rDgCWku5EvbfnZFFD8kFzxuzpZRJTZbmHY",
+              "RootIndex": "90B6B51EEFE093BFD2FBAE54393228773B18814510A308AA1D49D36D26CD995C"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "90B6B51EEFE093BFD2FBAE54393228773B18814510A308AA1D49D36D26CD995C",
+            "PreviousTxnID": "E5F210752E3F2D8A3D1CDBFA6D413EF07178D3C7F49D15B6D08F8387D5B3FF96",
+            "PreviousTxnLgrSeq": 17424
+          }
+        },
+        {
+          "CreatedNode": {
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "971E4B33CE83C21F42AA8889BD899FFB09456B0FDCF5A4FB52038D7EA4C68000",
+            "NewFields": {
+              "ExchangeRate": "52038d7ea4c68000",
+              "RootIndex": "971E4B33CE83C21F42AA8889BD899FFB09456B0FDCF5A4FB52038D7EA4C68000",
+              "TakerGetsMPT": "0000440975FFB7DF5FA61340D0E8BECC77E33A1C30C3399F",
+              "TakerPaysCurrency": "0000000000000000000000005553440000000000",
+              "TakerPaysIssuer": "1DE3517049223E2E55118DACD345BDFFB08265EE"
+            }
+          }
+        },
+        {
+          "CreatedNode": {
+            "LedgerEntryType": "Offer",
+            "LedgerIndex": "F9CB697A09E381EB70FC8537F6F41C5500136EDBFB9D1B2D3831FF283112C9FC",
+            "NewFields": {
+              "Account": "rDgCWku5EvbfnZFFD8kFzxuzpZRJTZbmHY",
+              "BookDirectory": "971E4B33CE83C21F42AA8889BD899FFB09456B0FDCF5A4FB52038D7EA4C68000",
+              "Sequence": 17420,
+              "TakerGets": {
+                "mpt_issuance_id": "0000440975FFB7DF5FA61340D0E8BECC77E33A1C30C3399F",
+                "value": "50000"
+              },
+              "TakerPays": {
+                "currency": "USD",
+                "issuer": "rsjpuu4SVse7ZUXdQ2BiL6on83QVVacz7K",
+                "value": "50"
+              }
+            }
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": []
+}

--- a/tests/txmeta/fixtures/iou-mpt-offer.json
+++ b/tests/txmeta/fixtures/iou-mpt-offer.json
@@ -1,0 +1,252 @@
+{
+  "description": "IOU/MPT exact offer match: 5000 raw MPT for 100 USD",
+  "tx": {
+    "Account": "rpnBMhEt99sA11g6fg7RKQq2dtoXFicHcJ",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 13053,
+    "Sequence": 13026,
+    "SigningPubKey": "EDA40B7D6CA816BC8085218C1ED581D64CB28F885B1EA1AB1DE1E8BB167CD97182",
+    "TakerGets": {
+      "mpt_issuance_id": "000032DE40D3C13FA16AB5F355F0333527EF84DADD4B36B0",
+      "value": "5000"
+    },
+    "TakerPays": {
+      "currency": "USD",
+      "issuer": "rG2a6FXUv2wQb68Ldp7tG3ipkupJvHR6i6",
+      "value": "100"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "CB6254D33F9421888C04FCB8897C460F191C53569373DA8ACA6FFD0C54088476C16DC6382B313B78B4FA5891D223B6124F5AAD0538CD431B303C9FDE1847600E",
+    "hash": "1642A155D2234AC6C12EF4CCA2B1D30924BF3E17B7038DC64DDEB3ED54C12126",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rpnBMhEt99sA11g6fg7RKQq2dtoXFicHcJ",
+              "Balance": "399999964",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 13027
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "19F65F49A209D6955E48905DDD1BD84A7A0A7CC11C328F82DCAD23E465AA8944",
+            "PreviousFields": {
+              "Balance": "399999976",
+              "Sequence": 13026
+            },
+            "PreviousTxnID": "23BFA1463761392B717F2713A0E321DF127CC67F4E92B1AC5737D706FD06AA77",
+            "PreviousTxnLgrSeq": 13030
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "-900"
+              },
+              "Flags": 131072,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rMYGEB4ehfF1MSQsfLvix49jqVLTSZksCA",
+                "value": "10000"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "rG2a6FXUv2wQb68Ldp7tG3ipkupJvHR6i6",
+                "value": "0"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "52F6A96D0913B0464B9D3BFFE4AF71280F2589BE30171EBDBF29CF94835F3F21",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "-1000"
+              }
+            },
+            "PreviousTxnID": "2CFDE231BDAE8108302187E8F7E4C0F5FBBC87D8137E60093D3F6BE936365FDC",
+            "PreviousTxnLgrSeq": 13031
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rMYGEB4ehfF1MSQsfLvix49jqVLTSZksCA",
+              "RootIndex": "5958434F782A4D1C9BE76BE14568B89507E19DEA1F1225EE6066F46E43BEF46C"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "5958434F782A4D1C9BE76BE14568B89507E19DEA1F1225EE6066F46E43BEF46C",
+            "PreviousTxnID": "5E7217821532E319330D840B433D5A8501C722EC01A78071C615B90117E8DF35",
+            "PreviousTxnLgrSeq": 13033
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "Account": "rMYGEB4ehfF1MSQsfLvix49jqVLTSZksCA",
+              "BookDirectory": "D1A8857F32877B4073FFCAAC542F24BB11DFE4F6D0E25EE95611C37937E08000",
+              "BookNode": "0",
+              "Flags": 0,
+              "OwnerNode": "0",
+              "PreviousTxnID": "5E7217821532E319330D840B433D5A8501C722EC01A78071C615B90117E8DF35",
+              "PreviousTxnLgrSeq": 13033,
+              "Sequence": 13025,
+              "TakerGets": {
+                "currency": "USD",
+                "issuer": "rG2a6FXUv2wQb68Ldp7tG3ipkupJvHR6i6",
+                "value": "0"
+              },
+              "TakerPays": {
+                "mpt_issuance_id": "000032DE40D3C13FA16AB5F355F0333527EF84DADD4B36B0",
+                "value": "0"
+              }
+            },
+            "LedgerEntryType": "Offer",
+            "LedgerIndex": "5C0E092A11DB053C47D54A80767CB9EB234C643957F1847A2817A040D5448AD8",
+            "PreviousFields": {
+              "TakerGets": {
+                "currency": "USD",
+                "issuer": "rG2a6FXUv2wQb68Ldp7tG3ipkupJvHR6i6",
+                "value": "100"
+              },
+              "TakerPays": {
+                "mpt_issuance_id": "000032DE40D3C13FA16AB5F355F0333527EF84DADD4B36B0",
+                "value": "5000"
+              }
+            }
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rMYGEB4ehfF1MSQsfLvix49jqVLTSZksCA",
+              "Balance": "399999964",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 13026
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "BB515D5D8177B55045ECA9505FB7B58244FA2FE0F05D8DDDC8212311CAFB51EA",
+            "PreviousFields": {
+              "OwnerCount": 3
+            },
+            "PreviousTxnID": "5E7217821532E319330D840B433D5A8501C722EC01A78071C615B90117E8DF35",
+            "PreviousTxnLgrSeq": 13033
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "ExchangeRate": "5611c37937e08000",
+              "Flags": 0,
+              "PreviousTxnID": "5E7217821532E319330D840B433D5A8501C722EC01A78071C615B90117E8DF35",
+              "PreviousTxnLgrSeq": 13033,
+              "RootIndex": "D1A8857F32877B4073FFCAAC542F24BB11DFE4F6D0E25EE95611C37937E08000",
+              "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+              "TakerGetsIssuer": "AACC5FF11A4B6914895A12585FABC805A47AD967",
+              "TakerPaysMPT": "000032DE40D3C13FA16AB5F355F0333527EF84DADD4B36B0"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "D1A8857F32877B4073FFCAAC542F24BB11DFE4F6D0E25EE95611C37937E08000"
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rpnBMhEt99sA11g6fg7RKQq2dtoXFicHcJ",
+              "Flags": 0,
+              "MPTAmount": "5000",
+              "MPTokenIssuanceID": "000032DE40D3C13FA16AB5F355F0333527EF84DADD4B36B0",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "D7E21FB49CAFBAE1CB5BB7A99A393441D15E21899010D3E87464D79467145D4F",
+            "PreviousFields": {
+              "MPTAmount": "10000"
+            },
+            "PreviousTxnID": "2354182122AAAD95B4FCB861283736042916447A9615D8205981511A472F14DD",
+            "PreviousTxnLgrSeq": 13032
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "100"
+              },
+              "Flags": 65536,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rG2a6FXUv2wQb68Ldp7tG3ipkupJvHR6i6",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "rpnBMhEt99sA11g6fg7RKQq2dtoXFicHcJ",
+                "value": "10000"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "EA13756A066FA698013D926198B68C9E9ACD3F2D1B188C3733670A5BFFE69817",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "0"
+              }
+            },
+            "PreviousTxnID": "0908F3562FCD08B589F0ACF9CD34B299E9AA48D14FF7D62395764B2106C1AE03",
+            "PreviousTxnLgrSeq": 13028
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rMYGEB4ehfF1MSQsfLvix49jqVLTSZksCA",
+              "Flags": 0,
+              "MPTAmount": "5000",
+              "MPTokenIssuanceID": "000032DE40D3C13FA16AB5F355F0333527EF84DADD4B36B0",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "EE4876F47000F0E2C0BAC006978903E40E66A473C1A7097E64D4D78506E2DDAF",
+            "PreviousFields": {},
+            "PreviousTxnID": "5A71113FB120DC8D7F2AF95073F61A0A552D7CFEA16DE11E1E52465A70D5D205",
+            "PreviousTxnLgrSeq": 13029
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": [
+    {
+      "hash": "1642A155D2234AC6C12EF4CCA2B1D30924BF3E17B7038DC64DDEB3ED54C12126",
+      "maker": "rMYGEB4ehfF1MSQsfLvix49jqVLTSZksCA",
+      "taker": "rpnBMhEt99sA11g6fg7RKQq2dtoXFicHcJ",
+      "sequence": 13025,
+      "takerPaid": {
+        "mpt_issuance_id": "000032DE40D3C13FA16AB5F355F0333527EF84DADD4B36B0",
+        "value": "5000"
+      },
+      "takerGot": {
+        "currency": "USD",
+        "issuer": "rG2a6FXUv2wQb68Ldp7tG3ipkupJvHR6i6",
+        "value": "100"
+      }
+    }
+  ]
+}

--- a/tests/txmeta/fixtures/iou-xrp-amm-deposit.json
+++ b/tests/txmeta/fixtures/iou-xrp-amm-deposit.json
@@ -1,0 +1,242 @@
+{
+  "description": "IOU/XRP AMM deposit (no trade): Bob deposits 50 USD + 10 XRP into AMM pool. 0 exchanges.",
+  "tx": {
+    "Account": "r5MK2hKChRwo6mrVGX63j9ouEdZto87LJ",
+    "Amount": {
+      "currency": "USD",
+      "issuer": "rLtrj2yVB6wj14mAcD3qP3djfiu7JewoyD",
+      "value": "50"
+    },
+    "Amount2": "10000000",
+    "Asset": {
+      "currency": "USD",
+      "issuer": "rLtrj2yVB6wj14mAcD3qP3djfiu7JewoyD"
+    },
+    "Asset2": {
+      "currency": "XRP"
+    },
+    "Fee": "12",
+    "Flags": 1048576,
+    "LastLedgerSequence": 26661,
+    "Sequence": 26636,
+    "SigningPubKey": "ED2004BD6D1F43F50B6F9B96D501DEA31E503671277765B552E4C85D524E03A14B",
+    "TransactionType": "AMMDeposit",
+    "TxnSignature": "1E2ADEB4E68DD62DF82FD62CD441D556EB21B94EA0FE7ABD99A9861D20B849F718E2FF62E31525A6D5A629693F21858F884BD6923E53A8D16FEA6A470CC6F808",
+    "hash": "77F57AC54AE58629A3CF505807E672B1FF52DF9EAB27B6D475B6B463CF477943",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "r5MK2hKChRwo6mrVGX63j9ouEdZto87LJ",
+              "RootIndex": "0061ED92936FE117FF6C2262C12689625EAC5FBC527EC33679E63AEF7CFD65B2"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "0061ED92936FE117FF6C2262C12689625EAC5FBC527EC33679E63AEF7CFD65B2",
+            "PreviousTxnID": "51EE0195D738C98471E7A2AF9580F9AF2F5B7169472EE9317D9936D20D97F9D7",
+            "PreviousTxnLgrSeq": 26638
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "AMMID": "D92AA4D7F06E2D1710F88F923D1019ACAAA16FD95AA8881F5A2DA4F1900CA04C",
+              "Account": "r9uAYznhqrpVeNh8tFgGcStcqBEZwiTcGq",
+              "Balance": "110000000",
+              "Flags": 26214400,
+              "OwnerCount": 1,
+              "Sequence": 0
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "0B4C9DF1072DB9959DEE6CEB3A72F66ECFC208C7811434EBCC067C0C2CA4364E",
+            "PreviousFields": {
+              "Balance": "100000000"
+            },
+            "PreviousTxnID": "E89C21A8307851DFED2C9D6677A4AA3ED552429DD1A943BEE01A3F6B017023B0",
+            "PreviousTxnLgrSeq": 26641
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "550"
+              },
+              "Flags": 16842752,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rLtrj2yVB6wj14mAcD3qP3djfiu7JewoyD",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "r9uAYznhqrpVeNh8tFgGcStcqBEZwiTcGq",
+                "value": "0"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "510729FE3582ABD51BB9B8D99397D33C8F7F9606964E9C67052E457E8D970611",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "500"
+              }
+            },
+            "PreviousTxnID": "E89C21A8307851DFED2C9D6677A4AA3ED552429DD1A943BEE01A3F6B017023B0",
+            "PreviousTxnLgrSeq": 26641
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "r9uAYznhqrpVeNh8tFgGcStcqBEZwiTcGq",
+              "RootIndex": "901F3754A04688B2634CB0D594F60EBDA45D1A029D3039447096FFC4BB9D19CD"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "901F3754A04688B2634CB0D594F60EBDA45D1A029D3039447096FFC4BB9D19CD",
+            "PreviousTxnID": "E89C21A8307851DFED2C9D6677A4AA3ED552429DD1A943BEE01A3F6B017023B0",
+            "PreviousTxnLgrSeq": 26641
+          }
+        },
+        {
+          "CreatedNode": {
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "98E4CD65AF789FB7513F241D8057D5447FE8C34F55E66863DD1AEBBA0DE7702D",
+            "NewFields": {
+              "Balance": {
+                "currency": "03930D02208264E2E40EC1B0C09E4DB96EE197B1",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "22360.6797749978"
+              },
+              "Flags": 1114112,
+              "HighLimit": {
+                "currency": "03930D02208264E2E40EC1B0C09E4DB96EE197B1",
+                "issuer": "r9uAYznhqrpVeNh8tFgGcStcqBEZwiTcGq",
+                "value": "0"
+              },
+              "LowLimit": {
+                "currency": "03930D02208264E2E40EC1B0C09E4DB96EE197B1",
+                "issuer": "r5MK2hKChRwo6mrVGX63j9ouEdZto87LJ",
+                "value": "0"
+              }
+            }
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "r5MK2hKChRwo6mrVGX63j9ouEdZto87LJ",
+              "Balance": "989999976",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 26637
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "C0FD9FB2340EF010ABB961F43CAD1B4B3101D10A39C69B89D2B730B880FBF43B",
+            "PreviousFields": {
+              "Balance": "999999988",
+              "OwnerCount": 1,
+              "Sequence": 26636
+            },
+            "PreviousTxnID": "51EE0195D738C98471E7A2AF9580F9AF2F5B7169472EE9317D9936D20D97F9D7",
+            "PreviousTxnLgrSeq": 26638
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "950"
+              },
+              "Flags": 65536,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rLtrj2yVB6wj14mAcD3qP3djfiu7JewoyD",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "r5MK2hKChRwo6mrVGX63j9ouEdZto87LJ",
+                "value": "10000"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "C274A068C466D6290458404417ABD0D39C3A788D261524CEF76979C1A254B4FE",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "1000"
+              }
+            },
+            "PreviousTxnID": "77F9931BC94FB3527F86FC8B836701D377B0D7588DEB59976490EEDB611833C7",
+            "PreviousTxnLgrSeq": 26640
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "r9uAYznhqrpVeNh8tFgGcStcqBEZwiTcGq",
+              "Asset": {
+                "currency": "XRP"
+              },
+              "Asset2": {
+                "currency": "USD",
+                "issuer": "rLtrj2yVB6wj14mAcD3qP3djfiu7JewoyD"
+              },
+              "AuctionSlot": {
+                "Account": "rMWhWY2mCgFAuZjZVCPfDyD7ooKknVBD8",
+                "Expiration": 829780907,
+                "Price": {
+                  "currency": "03930D02208264E2E40EC1B0C09E4DB96EE197B1",
+                  "issuer": "r9uAYznhqrpVeNh8tFgGcStcqBEZwiTcGq",
+                  "value": "0"
+                }
+              },
+              "Flags": 0,
+              "LPTokenBalance": {
+                "currency": "03930D02208264E2E40EC1B0C09E4DB96EE197B1",
+                "issuer": "r9uAYznhqrpVeNh8tFgGcStcqBEZwiTcGq",
+                "value": "245967.4775249767"
+              },
+              "OwnerNode": "0",
+              "VoteSlots": [
+                {
+                  "VoteEntry": {
+                    "Account": "rMWhWY2mCgFAuZjZVCPfDyD7ooKknVBD8",
+                    "VoteWeight": 100000
+                  }
+                }
+              ]
+            },
+            "LedgerEntryType": "AMM",
+            "LedgerIndex": "D92AA4D7F06E2D1710F88F923D1019ACAAA16FD95AA8881F5A2DA4F1900CA04C",
+            "PreviousFields": {
+              "LPTokenBalance": {
+                "currency": "03930D02208264E2E40EC1B0C09E4DB96EE197B1",
+                "issuer": "r9uAYznhqrpVeNh8tFgGcStcqBEZwiTcGq",
+                "value": "223606.7977499789"
+              }
+            },
+            "PreviousTxnID": "E89C21A8307851DFED2C9D6677A4AA3ED552429DD1A943BEE01A3F6B017023B0",
+            "PreviousTxnLgrSeq": 26641
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": []
+}

--- a/tests/txmeta/fixtures/iou-xrp-amm-offer.json
+++ b/tests/txmeta/fixtures/iou-xrp-amm-offer.json
@@ -1,0 +1,172 @@
+{
+  "description": "IOU/XRP AMM consumption: XRP for USD via AMM pool",
+  "tx": {
+    "Account": "rw8QihSRKE27pZZhnw5c6UjnDvqi2a3tME",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 15655,
+    "Sequence": 15631,
+    "SigningPubKey": "EDA446655D5B84B199FE6F0AE9D09159CFB3721657A7532552B42118B1B58F2548",
+    "TakerGets": "15000000",
+    "TakerPays": {
+      "currency": "USD",
+      "issuer": "rBtB77y7dPE8fZ1ZvFHdWPBW86PbAu5UpY",
+      "value": "50"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "3F1AA4A227923CA7C158342E883CD07D201EA17B6E4A305484512AA37842E9A9FFF91423A685BEC99EB8E1F4FBD354737B44FD3CA9C11A4502341D95BC01D90F",
+    "hash": "694B6B666BDC92CDA689076BCC5FEBE863D1070CBEC7A5857748B0FC1B98BD63",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rBtB77y7dPE8fZ1ZvFHdWPBW86PbAu5UpY",
+              "RootIndex": "24617E1A75A40EAC65EA4BB51F04042118A7ACCCC597334E6AECC3ED991A66B5"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "24617E1A75A40EAC65EA4BB51F04042118A7ACCCC597334E6AECC3ED991A66B5",
+            "PreviousTxnID": "7864FCB174DCA0602F71D82ED0F521AFC56C0C917ADB21A0AF706237EA20565D",
+            "PreviousTxnLgrSeq": 15635
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rw8QihSRKE27pZZhnw5c6UjnDvqi2a3tME",
+              "Balance": "988888876",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 15632
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "2F5A97E07A9EDAA3A0EB61BAA48E2EB592F103B7FD558FAD50A8D6A93B78F1FA",
+            "PreviousFields": {
+              "Balance": "1000000000",
+              "OwnerCount": 0,
+              "Sequence": 15631
+            },
+            "PreviousTxnID": "2A12901CA25B8AFBA206FAE725F6600F5A8EFAE0ECEF141F14D7EB42B149F3D6",
+            "PreviousTxnLgrSeq": 15631
+          }
+        },
+        {
+          "CreatedNode": {
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "38481C7BDD17C0C652DA8E5093C2E67F85219DDF27EF687BEA02B0B24631FD56",
+            "NewFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "50"
+              },
+              "Flags": 1114112,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rBtB77y7dPE8fZ1ZvFHdWPBW86PbAu5UpY",
+                "value": "0"
+              },
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "rw8QihSRKE27pZZhnw5c6UjnDvqi2a3tME",
+                "value": "0"
+              }
+            }
+          }
+        },
+        {
+          "ModifiedNode": {
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "4282ACB7BDCEB7A2BC7E9DCE157E58EAC314C52283832C7FE66D519E34D73489",
+            "PreviousTxnID": "7864FCB174DCA0602F71D82ED0F521AFC56C0C917ADB21A0AF706237EA20565D",
+            "PreviousTxnLgrSeq": 15635
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "450"
+              },
+              "Flags": 16842752,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rBtB77y7dPE8fZ1ZvFHdWPBW86PbAu5UpY",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "rscZrXvHsEXuei5dzTtWhqX4vzFcwWMRTx",
+                "value": "0"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "5BEF22010334D3F769F53C7DF93ADC60B8C43AD962ACE43E363D45A4566ABC2D",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "500"
+              }
+            },
+            "PreviousTxnID": "7864FCB174DCA0602F71D82ED0F521AFC56C0C917ADB21A0AF706237EA20565D",
+            "PreviousTxnLgrSeq": 15635
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "AMMID": "649F21E8AD74032158D5E93BA3A64E15676DC21426887642B4491B892DFB1AA9",
+              "Account": "rscZrXvHsEXuei5dzTtWhqX4vzFcwWMRTx",
+              "Balance": "111111112",
+              "Flags": 26214400,
+              "OwnerCount": 1,
+              "Sequence": 0
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "9E2494E9FE702AB57D154C752E625CF2A2F725F7F22DC83A269C0AC4E882C785",
+            "PreviousFields": {
+              "Balance": "100000000"
+            },
+            "PreviousTxnID": "7864FCB174DCA0602F71D82ED0F521AFC56C0C917ADB21A0AF706237EA20565D",
+            "PreviousTxnLgrSeq": 15635
+          }
+        },
+        {
+          "CreatedNode": {
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "FE8FFFF588F186C1CD961BF0943C3F1A506707C8D8F4A452413BC651497AE222",
+            "NewFields": {
+              "Owner": "rw8QihSRKE27pZZhnw5c6UjnDvqi2a3tME",
+              "RootIndex": "FE8FFFF588F186C1CD961BF0943C3F1A506707C8D8F4A452413BC651497AE222"
+            }
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": [
+    {
+      "hash": "694B6B666BDC92CDA689076BCC5FEBE863D1070CBEC7A5857748B0FC1B98BD63",
+      "maker": "rscZrXvHsEXuei5dzTtWhqX4vzFcwWMRTx",
+      "taker": "rw8QihSRKE27pZZhnw5c6UjnDvqi2a3tME",
+      "amm": "649F21E8AD74032158D5E93BA3A64E15676DC21426887642B4491B892DFB1AA9",
+      "takerPaid": {
+        "currency": "XRP",
+        "value": "11.111112"
+      },
+      "takerGot": {
+        "currency": "USD",
+        "issuer": "rBtB77y7dPE8fZ1ZvFHdWPBW86PbAu5UpY",
+        "value": "50"
+      }
+    }
+  ]
+}

--- a/tests/txmeta/fixtures/iou-xrp-offer.json
+++ b/tests/txmeta/fixtures/iou-xrp-offer.json
@@ -1,0 +1,211 @@
+{
+  "description": "IOU/XRP exact offer match: 10 XRP for 500 USD",
+  "tx": {
+    "Account": "rKzATGY9Uq5jRH9dk7EXkMSeszSUegoWHn",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 10866,
+    "Sequence": 10841,
+    "SigningPubKey": "ED74EC8C785C4223220A87349904DCF8F6DF1421F15BDBB41259B9A6C0BB047A97",
+    "TakerGets": "10000000",
+    "TakerPays": {
+      "currency": "USD",
+      "issuer": "rJVDp2SxNdMyHVZbJk1kqevhEqffvptGTa",
+      "value": "500"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "9F78A9E67C1CCEB1DDA3DB0E30939FD73656EE823BB50CC3DEF437BD4A35CFD5E5F0EF8EF99CC62D456B88A405ADDDB4B93F3C29A72B760152505399C9D0B909",
+    "hash": "C82A7EED0847AE501773862F94833070AD1764ADE2F5C546FA914BF2D8DF7BBE",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rKzATGY9Uq5jRH9dk7EXkMSeszSUegoWHn",
+              "Balance": "389999976",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 10842
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "4B483FA94165C348556128579C11F2FF35E19652209A8746D9C4DC320619DB7B",
+            "PreviousFields": {
+              "Balance": "399999988",
+              "Sequence": 10841
+            },
+            "PreviousTxnID": "6D90645D005C1D0BD5F4478B28B0944340F980A9F0FB610B0ED4CD043651CD2E",
+            "PreviousTxnLgrSeq": 10843
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rspYLR9rDNXRkZXzLtRxtnw852Thmdyizb",
+              "RootIndex": "96F88D24EDDF1211CE11E2EA513A85464577D4ADAFC0CEAE62A4317C8C4FD16A"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "96F88D24EDDF1211CE11E2EA513A85464577D4ADAFC0CEAE62A4317C8C4FD16A",
+            "PreviousTxnID": "1C347F2877FEA86C9A6D3C437BDA2F529BBE258FC95188E7FF5AA009B71DB845",
+            "PreviousTxnLgrSeq": 10846
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "Account": "rspYLR9rDNXRkZXzLtRxtnw852Thmdyizb",
+              "BookDirectory": "F5797B21F3C2152FDC17680AAC9BFC811E9D164403CA99BF59071AFD498D0000",
+              "BookNode": "0",
+              "Flags": 0,
+              "OwnerNode": "0",
+              "PreviousTxnID": "1C347F2877FEA86C9A6D3C437BDA2F529BBE258FC95188E7FF5AA009B71DB845",
+              "PreviousTxnLgrSeq": 10846,
+              "Sequence": 10839,
+              "TakerGets": {
+                "currency": "USD",
+                "issuer": "rJVDp2SxNdMyHVZbJk1kqevhEqffvptGTa",
+                "value": "0"
+              },
+              "TakerPays": "0"
+            },
+            "LedgerEntryType": "Offer",
+            "LedgerIndex": "9901B6D69F57E609BD76B11B1202A9826AAD6E00ABDB6A5F0FAB23FB91CD54F3",
+            "PreviousFields": {
+              "TakerGets": {
+                "currency": "USD",
+                "issuer": "rJVDp2SxNdMyHVZbJk1kqevhEqffvptGTa",
+                "value": "500"
+              },
+              "TakerPays": "10000000"
+            }
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "-1500"
+              },
+              "Flags": 131072,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rKzATGY9Uq5jRH9dk7EXkMSeszSUegoWHn",
+                "value": "10000"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "rJVDp2SxNdMyHVZbJk1kqevhEqffvptGTa",
+                "value": "0"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "9AFE04E14259D342155C69D7629026F89A95CC28D593FF64EBA508C3108219FF",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "-1000"
+              }
+            },
+            "PreviousTxnID": "5AA19CE9E799AAF8C9AEBA99F86C4EF50424B78218AFA76E4D07F2230DF69A69",
+            "PreviousTxnLgrSeq": 10845
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "500"
+              },
+              "Flags": 65536,
+              "HighLimit": {
+                "currency": "USD",
+                "issuer": "rJVDp2SxNdMyHVZbJk1kqevhEqffvptGTa",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "USD",
+                "issuer": "rspYLR9rDNXRkZXzLtRxtnw852Thmdyizb",
+                "value": "10000"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "AE4E9C065E5A121EDB68A8629B0EAA87045FCA5FBE40AD053C57A86B0F562445",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "USD",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "1000"
+              }
+            },
+            "PreviousTxnID": "065FC88120AC45BA3BB36392E3C2A02AD9280AA55C2B33EC0CE8134D46E5CA0B",
+            "PreviousTxnLgrSeq": 10844
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rspYLR9rDNXRkZXzLtRxtnw852Thmdyizb",
+              "Balance": "409999976",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 10840
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "B54D13DCC3A8518095971833F35424E94DD37D0BE6B18AD8F6A6D96131DB14BF",
+            "PreviousFields": {
+              "Balance": "399999976",
+              "OwnerCount": 2
+            },
+            "PreviousTxnID": "1C347F2877FEA86C9A6D3C437BDA2F529BBE258FC95188E7FF5AA009B71DB845",
+            "PreviousTxnLgrSeq": 10846
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "ExchangeRate": "59071afd498d0000",
+              "Flags": 0,
+              "PreviousTxnID": "1C347F2877FEA86C9A6D3C437BDA2F529BBE258FC95188E7FF5AA009B71DB845",
+              "PreviousTxnLgrSeq": 10846,
+              "RootIndex": "F5797B21F3C2152FDC17680AAC9BFC811E9D164403CA99BF59071AFD498D0000",
+              "TakerGetsCurrency": "0000000000000000000000005553440000000000",
+              "TakerGetsIssuer": "BFCFD335F4869CEF0EECA3A1437F9F26A0582A56",
+              "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+              "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "F5797B21F3C2152FDC17680AAC9BFC811E9D164403CA99BF59071AFD498D0000"
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": [
+    {
+      "hash": "C82A7EED0847AE501773862F94833070AD1764ADE2F5C546FA914BF2D8DF7BBE",
+      "maker": "rspYLR9rDNXRkZXzLtRxtnw852Thmdyizb",
+      "taker": "rKzATGY9Uq5jRH9dk7EXkMSeszSUegoWHn",
+      "sequence": 10839,
+      "takerPaid": {
+        "currency": "XRP",
+        "value": "10"
+      },
+      "takerGot": {
+        "currency": "USD",
+        "issuer": "rJVDp2SxNdMyHVZbJk1kqevhEqffvptGTa",
+        "value": "500"
+      }
+    }
+  ]
+}

--- a/tests/txmeta/fixtures/mpt-mpt-amm-offer.json
+++ b/tests/txmeta/fixtures/mpt-mpt-amm-offer.json
@@ -1,0 +1,118 @@
+{
+  "description": "MPT/MPT AMM non-consumption: offer does NOT cross",
+  "tx": {
+    "Account": "rayciN2ycB42dgMWDzAxrFp8T7KDM6DDy4",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 17463,
+    "Sequence": 17435,
+    "SigningPubKey": "EDBD7E2B7237F6BF9C7195336B3044AC46FF7113AC12530C27995D5AE1F75833D2",
+    "TakerGets": {
+      "mpt_issuance_id": "00004417EF984FEF44F4D91E946C2F55C57DBA383CB759A3",
+      "value": "100"
+    },
+    "TakerPays": {
+      "mpt_issuance_id": "000044162F85DFA6911C88A1D9EF2748351230A5CBFAEFC7",
+      "value": "100"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "2172F8C1E11EABAEE4D78E56C29F098DF20EEA92A87F79866CEE5B25CB2E66331E7EA3698DCF303597E1AA5823AC90AEFDC7A691BB35DA681DCB80D4F4D1A50C",
+    "hash": "9252F797BD8C78C018AE016D88F296DEA22899F43EFD0C2EBEE61AB636AE3091",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rayciN2ycB42dgMWDzAxrFp8T7KDM6DDy4",
+              "Flags": 0,
+              "MPTAmount": "100",
+              "MPTokenIssuanceID": "000044162F85DFA6911C88A1D9EF2748351230A5CBFAEFC7",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "140995E1D698514BA2441B22FE655B5F3D9E0F282F2AE3B34DD44F2254F1971A",
+            "PreviousFields": {},
+            "PreviousTxnID": "0691B95EED177D80F46916084E22F7DE0E971E661B12EA5D83392B128940453C",
+            "PreviousTxnLgrSeq": 17438
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rayciN2ycB42dgMWDzAxrFp8T7KDM6DDy4",
+              "Flags": 0,
+              "MPTAmount": "999979",
+              "MPTokenIssuanceID": "00004417EF984FEF44F4D91E946C2F55C57DBA383CB759A3",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "38BBA4B6CE2AB2A435F40EBC0A9DE5AA0FFE6C5D3EBDC673548613DAFA45AED0",
+            "PreviousFields": {
+              "MPTAmount": "1000000"
+            },
+            "PreviousTxnID": "FAE62F76E777540AD82D05BF2456C497919D1E991F8E01E3D7044B5BABDA5493",
+            "PreviousTxnLgrSeq": 17442
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rPSx7ke8jzeJvERzVpjnTWLe42xmWnTmYE",
+              "Flags": 4,
+              "MPTAmount": "499900",
+              "MPTokenIssuanceID": "000044162F85DFA6911C88A1D9EF2748351230A5CBFAEFC7",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "848524B29163B02D21F24A1443153A1F28ACDB899AB170C7F62D418D63E6D067",
+            "PreviousFields": {
+              "MPTAmount": "500000"
+            },
+            "PreviousTxnID": "761DE1BB38607A8EC081406F3EA9DF00C4B75219248C3DF064ACC7E97B21B6BF",
+            "PreviousTxnLgrSeq": 17443
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rayciN2ycB42dgMWDzAxrFp8T7KDM6DDy4",
+              "Balance": "999999964",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 17436
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "9E0F8345B2F9F3204EB8577BC9F9A9AA203645C4133C4039078AB95FD1303FDD",
+            "PreviousFields": {
+              "Balance": "999999976",
+              "Sequence": 17435
+            },
+            "PreviousTxnID": "2FDCC39A3050FA2A93E12B7E8E885FA15A5BD5C84803798413EA02C60B68ECA0",
+            "PreviousTxnLgrSeq": 17439
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rPSx7ke8jzeJvERzVpjnTWLe42xmWnTmYE",
+              "Flags": 4,
+              "MPTAmount": "100021",
+              "MPTokenIssuanceID": "00004417EF984FEF44F4D91E946C2F55C57DBA383CB759A3",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "A869B41B6DEA3404ECB184242DF637BC043C3EAD8C331DF23C6289E7AFAB5E24",
+            "PreviousFields": {
+              "MPTAmount": "100000"
+            },
+            "PreviousTxnID": "761DE1BB38607A8EC081406F3EA9DF00C4B75219248C3DF064ACC7E97B21B6BF",
+            "PreviousTxnLgrSeq": 17443
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": []
+}

--- a/tests/txmeta/fixtures/mpt-mpt-offer.json
+++ b/tests/txmeta/fixtures/mpt-mpt-offer.json
@@ -1,0 +1,211 @@
+{
+  "description": "MPT/MPT exact offer match: 20000 raw MPT-B for 500 raw MPT-A",
+  "tx": {
+    "Account": "r4y5ZebdHVPDTB9FrUvBPXJ5uWkqZJ8Dzd",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 13794,
+    "Sequence": 13767,
+    "SigningPubKey": "EDFB7BAB9EB8A65297F6EF81804092509EB80D35E8E9FF05555FBF30F575CF3D8C",
+    "TakerGets": {
+      "mpt_issuance_id": "000035C3EF87206A038CB19EBA940D085533E90F5652B540",
+      "value": "20000"
+    },
+    "TakerPays": {
+      "mpt_issuance_id": "000035C2BEC3E1B595B81356315F272DA0210595C477D999",
+      "value": "500"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "2DC5FCFCBDFBD042757C6959C0EEAADF3BA16F5458673903F2B6EDC90DF768407B22F2B0E03322B7ADC4E39B7A4B09FEBF8610E955065AAD26155B955AFBAE0D",
+    "hash": "6B39E0B22F87884A5AED2A7C9ACBD37A9E43349A467144AF17BDA180B2708B26",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rfedM6KrcATyXjFg49FEFMiiT1y3jcnpmR",
+              "RootIndex": "05529D8175EF4F3AC20F70B56A36ABCC5C8E38A6D55A137BC7D5775A32B92334"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "05529D8175EF4F3AC20F70B56A36ABCC5C8E38A6D55A137BC7D5775A32B92334",
+            "PreviousTxnID": "7B402EBCABB167345491F201F7BF87FBF84453C594B854EEBC695C7761028B51",
+            "PreviousTxnLgrSeq": 13774
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rfedM6KrcATyXjFg49FEFMiiT1y3jcnpmR",
+              "Flags": 0,
+              "MPTAmount": "20000",
+              "MPTokenIssuanceID": "000035C3EF87206A038CB19EBA940D085533E90F5652B540",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "4147635B965968AF2F035843D8AF63069F50F24F29EFC06615979229DD0193CC",
+            "PreviousFields": {},
+            "PreviousTxnID": "857A0331D1BE5C4ACD5F9C32A6699D35EB88A0F2333182C6AB1D46FEE88FAA6B",
+            "PreviousTxnLgrSeq": 13769
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "r4y5ZebdHVPDTB9FrUvBPXJ5uWkqZJ8Dzd",
+              "Flags": 0,
+              "MPTAmount": "500",
+              "MPTokenIssuanceID": "000035C2BEC3E1B595B81356315F272DA0210595C477D999",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "588CB75D35635F72164DCD7BBD7C830686FBF4800B33CCDF96BA03BA27DFC2A6",
+            "PreviousFields": {},
+            "PreviousTxnID": "320F833F23C6B94384BF3BCE5C95214A78B87A7554D33885C5172A7148FD525D",
+            "PreviousTxnLgrSeq": 13770
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rfedM6KrcATyXjFg49FEFMiiT1y3jcnpmR",
+              "Flags": 0,
+              "MPTAmount": "500",
+              "MPTokenIssuanceID": "000035C2BEC3E1B595B81356315F272DA0210595C477D999",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "5FD71B8C909AA6F0E15762001ADE2AC00A09586BE8C51FBE0B63A585487D9D41",
+            "PreviousFields": {
+              "MPTAmount": "1000"
+            },
+            "PreviousTxnID": "6A819898948CEB871F860E21CED04E02BC56D4A5725986EFB0B32D6CA3038067",
+            "PreviousTxnLgrSeq": 13772
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "r4y5ZebdHVPDTB9FrUvBPXJ5uWkqZJ8Dzd",
+              "Balance": "399999964",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 13768
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "9F51B6C58E09B622349F36FF0248BD69C7D25B1D0463B231722326814CEFD6CE",
+            "PreviousFields": {
+              "Balance": "399999976",
+              "Sequence": 13767
+            },
+            "PreviousTxnID": "49F47270A643AF2F1E174CFEC116814976DFA1FAA85EF2E96BCB9E5061D3AC48",
+            "PreviousTxnLgrSeq": 13771
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "ExchangeRate": "560e35fa931a0000",
+              "Flags": 0,
+              "PreviousTxnID": "7B402EBCABB167345491F201F7BF87FBF84453C594B854EEBC695C7761028B51",
+              "PreviousTxnLgrSeq": 13774,
+              "RootIndex": "A58BC08D4005593A0FD6D4FD4B646D2AEE3B0DB7730A36E7560E35FA931A0000",
+              "TakerGetsMPT": "000035C2BEC3E1B595B81356315F272DA0210595C477D999",
+              "TakerPaysMPT": "000035C3EF87206A038CB19EBA940D085533E90F5652B540"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "A58BC08D4005593A0FD6D4FD4B646D2AEE3B0DB7730A36E7560E35FA931A0000"
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "r4y5ZebdHVPDTB9FrUvBPXJ5uWkqZJ8Dzd",
+              "Flags": 0,
+              "MPTAmount": "30000",
+              "MPTokenIssuanceID": "000035C3EF87206A038CB19EBA940D085533E90F5652B540",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "AF49B4F9127C6B4EF2DAF2C20D4F0FF0EB03776973F905D47F4BDFF7DA52983C",
+            "PreviousFields": {
+              "MPTAmount": "50000"
+            },
+            "PreviousTxnID": "666FF7F984533276781FB7ABC68B83C8AB996EA41D0B06276675AC1C57B41AC2",
+            "PreviousTxnLgrSeq": 13773
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "Account": "rfedM6KrcATyXjFg49FEFMiiT1y3jcnpmR",
+              "BookDirectory": "A58BC08D4005593A0FD6D4FD4B646D2AEE3B0DB7730A36E7560E35FA931A0000",
+              "BookNode": "0",
+              "Flags": 0,
+              "OwnerNode": "0",
+              "PreviousTxnID": "7B402EBCABB167345491F201F7BF87FBF84453C594B854EEBC695C7761028B51",
+              "PreviousTxnLgrSeq": 13774,
+              "Sequence": 13766,
+              "TakerGets": {
+                "mpt_issuance_id": "000035C2BEC3E1B595B81356315F272DA0210595C477D999",
+                "value": "0"
+              },
+              "TakerPays": {
+                "mpt_issuance_id": "000035C3EF87206A038CB19EBA940D085533E90F5652B540",
+                "value": "0"
+              }
+            },
+            "LedgerEntryType": "Offer",
+            "LedgerIndex": "D5FFFDFEDD2C537E959BCF87E7052C921B26E21E1F8A5D7B8BEC26B2FF0F2A20",
+            "PreviousFields": {
+              "TakerGets": {
+                "mpt_issuance_id": "000035C2BEC3E1B595B81356315F272DA0210595C477D999",
+                "value": "500"
+              },
+              "TakerPays": {
+                "mpt_issuance_id": "000035C3EF87206A038CB19EBA940D085533E90F5652B540",
+                "value": "20000"
+              }
+            }
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rfedM6KrcATyXjFg49FEFMiiT1y3jcnpmR",
+              "Balance": "399999964",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 13767
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "E5001319C143ACE91D30A95CA6C8CBEC552F0751D5C6C39497389C0156CD0CD6",
+            "PreviousFields": {
+              "OwnerCount": 3
+            },
+            "PreviousTxnID": "7B402EBCABB167345491F201F7BF87FBF84453C594B854EEBC695C7761028B51",
+            "PreviousTxnLgrSeq": 13774
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": [
+    {
+      "hash": "6B39E0B22F87884A5AED2A7C9ACBD37A9E43349A467144AF17BDA180B2708B26",
+      "maker": "rfedM6KrcATyXjFg49FEFMiiT1y3jcnpmR",
+      "taker": "r4y5ZebdHVPDTB9FrUvBPXJ5uWkqZJ8Dzd",
+      "sequence": 13766,
+      "takerPaid": {
+        "mpt_issuance_id": "000035C3EF87206A038CB19EBA940D085533E90F5652B540",
+        "value": "20000"
+      },
+      "takerGot": {
+        "mpt_issuance_id": "000035C2BEC3E1B595B81356315F272DA0210595C477D999",
+        "value": "500"
+      }
+    }
+  ]
+}

--- a/tests/txmeta/fixtures/mpt-xrp-amm-deposit.json
+++ b/tests/txmeta/fixtures/mpt-xrp-amm-deposit.json
@@ -1,0 +1,205 @@
+{
+  "description": "MPT/XRP AMM deposit (no trade): Bob deposits 50000 MPT + 10 XRP into AMM pool. 0 exchanges.",
+  "tx": {
+    "Account": "rUX7KVnt4MocYuR43h9NheEhjxNtguThT5",
+    "Amount": {
+      "mpt_issuance_id": "000068131067BCD7C22517DFE865E938AB1DF668A546B22D",
+      "value": "50000"
+    },
+    "Amount2": "10000000",
+    "Asset": {
+      "mpt_issuance_id": "000068131067BCD7C22517DFE865E938AB1DF668A546B22D"
+    },
+    "Asset2": {
+      "currency": "XRP"
+    },
+    "Fee": "12",
+    "Flags": 1048576,
+    "LastLedgerSequence": 26671,
+    "Sequence": 26646,
+    "SigningPubKey": "EDD0E1FCA9C64030EB6479672888491FD3F87D1A16C603871BBE162FEA821B0130",
+    "TransactionType": "AMMDeposit",
+    "TxnSignature": "F69099D27E51E23B9B1B0614FAEB3673BFDE62263750DF1C7C79AE99D0D22566E44302BFE8B6575488B377B62D6B4AFFA2B513D41F6FE7CDA97154993C338501",
+    "hash": "F7D08E7E743FFD6181C9D034E6C303D35F9B795322DBE3EFEA6BE40FD4BEF8AC",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "AMMID": "0BD398A9BCA45003AAE646AE305558BE82A4FA394FB14E4FEBF5CD66D07C9CA4",
+              "Account": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+              "Balance": "110000000",
+              "Flags": 26214400,
+              "OwnerCount": 0,
+              "Sequence": 0
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "017058D3E442FEF8D68892573BA81A2BBAC541BDBD7455DB4062360E826ACCD3",
+            "PreviousFields": {
+              "Balance": "100000000"
+            },
+            "PreviousTxnID": "AB40364995CEC7FF0890AFF826CE26A50C4F34AA849C87DF52359457ADAEDE9A",
+            "PreviousTxnLgrSeq": 26651
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+              "Asset": {
+                "mpt_issuance_id": "000068131067BCD7C22517DFE865E938AB1DF668A546B22D"
+              },
+              "Asset2": {
+                "currency": "XRP"
+              },
+              "AuctionSlot": {
+                "Account": "rDevP6bzEcCMiMB2qJwzNWhhzbrVU1EAa2",
+                "Expiration": 829780917,
+                "Price": {
+                  "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                  "issuer": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+                  "value": "0"
+                }
+              },
+              "Flags": 0,
+              "LPTokenBalance": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+                "value": "7778174.593052022"
+              },
+              "OwnerNode": "0",
+              "VoteSlots": [
+                {
+                  "VoteEntry": {
+                    "Account": "rDevP6bzEcCMiMB2qJwzNWhhzbrVU1EAa2",
+                    "VoteWeight": 100000
+                  }
+                }
+              ]
+            },
+            "LedgerEntryType": "AMM",
+            "LedgerIndex": "0BD398A9BCA45003AAE646AE305558BE82A4FA394FB14E4FEBF5CD66D07C9CA4",
+            "PreviousFields": {
+              "LPTokenBalance": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+                "value": "7071067.811865475"
+              }
+            },
+            "PreviousTxnID": "AB40364995CEC7FF0890AFF826CE26A50C4F34AA849C87DF52359457ADAEDE9A",
+            "PreviousTxnLgrSeq": 26651
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rUX7KVnt4MocYuR43h9NheEhjxNtguThT5",
+              "Balance": "989999976",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 26647
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "39C3BF20ABED593EEAA83F83850B7CA9C10F51E5AF93ECCB712CD6B504D17CA9",
+            "PreviousFields": {
+              "Balance": "999999988",
+              "OwnerCount": 1,
+              "Sequence": 26646
+            },
+            "PreviousTxnID": "DF9127EED799D83600154C0DBCF1413AD61D0811C72F570D76F116EEC7150017",
+            "PreviousTxnLgrSeq": 26648
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+              "RootIndex": "47580E388CEDA5593636CF140D8B601DA822F2FB3ECE0FF9E700BF1DAE679C8E"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "47580E388CEDA5593636CF140D8B601DA822F2FB3ECE0FF9E700BF1DAE679C8E",
+            "PreviousTxnID": "AB40364995CEC7FF0890AFF826CE26A50C4F34AA849C87DF52359457ADAEDE9A",
+            "PreviousTxnLgrSeq": 26651
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rUX7KVnt4MocYuR43h9NheEhjxNtguThT5",
+              "RootIndex": "4EC82F1CD5DF1C43EEB43338034D00FA211FEB9AB7D8132E7550D1BEB17CF1C4"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "4EC82F1CD5DF1C43EEB43338034D00FA211FEB9AB7D8132E7550D1BEB17CF1C4",
+            "PreviousTxnID": "DF9127EED799D83600154C0DBCF1413AD61D0811C72F570D76F116EEC7150017",
+            "PreviousTxnLgrSeq": 26648
+          }
+        },
+        {
+          "CreatedNode": {
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "CD89783E718E1D477DFA0808AE244B6D7281FF0B07DD53BD3FA9DEFD4499B5D1",
+            "NewFields": {
+              "Balance": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "707106.781186547"
+              },
+              "Flags": 1114112,
+              "HighLimit": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+                "value": "0"
+              },
+              "LowLimit": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rUX7KVnt4MocYuR43h9NheEhjxNtguThT5",
+                "value": "0"
+              }
+            }
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rUX7KVnt4MocYuR43h9NheEhjxNtguThT5",
+              "Flags": 0,
+              "MPTAmount": "950000",
+              "MPTokenIssuanceID": "000068131067BCD7C22517DFE865E938AB1DF668A546B22D",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "D57584A8104514C1D32D5D0F281E8662464C121E2404F4A353E5DA9A63ACC838",
+            "PreviousFields": {
+              "MPTAmount": "1000000"
+            },
+            "PreviousTxnID": "A3BDF5E7D83DD04B237617F521DF9BFA45F2FD9614247BE87BEFD29C99738850",
+            "PreviousTxnLgrSeq": 26650
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+              "Flags": 4,
+              "MPTAmount": "550000",
+              "MPTokenIssuanceID": "000068131067BCD7C22517DFE865E938AB1DF668A546B22D",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "E3B885205505E03CDF774EA04842A48778BBD53CC40170D4FE74C88CCD205B8C",
+            "PreviousFields": {
+              "MPTAmount": "500000"
+            },
+            "PreviousTxnID": "AB40364995CEC7FF0890AFF826CE26A50C4F34AA849C87DF52359457ADAEDE9A",
+            "PreviousTxnLgrSeq": 26651
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": []
+}

--- a/tests/txmeta/fixtures/mpt-xrp-amm-offer.json
+++ b/tests/txmeta/fixtures/mpt-xrp-amm-offer.json
@@ -1,0 +1,113 @@
+{
+  "description": "MPT/XRP AMM consumption: XRP for raw MPT via AMM pool",
+  "tx": {
+    "Account": "rU3ovNwQLBDocSsW4cS71szfCmjkF8eTZr",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 16255,
+    "Sequence": 16231,
+    "SigningPubKey": "ED13E0E446C72026E786E470E6546C2B3B43AAC6F7CD2F419D2C7D3593C0EAB0F6",
+    "TakerGets": "10000000",
+    "TakerPays": {
+      "mpt_issuance_id": "00003F6375D00DFDB36367033BB1A4290476D06B211C5028",
+      "value": "100"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "2190B699DABE7291E3BB53E5DB4BEEC216FDE484700F3553A5D1886DEE97E3F9357E5DF2DBD64451926449E6DDCEDD19A555092ACD609E25224F1090D77DA50D",
+    "hash": "41809FF2487C77B0FD1E358323B71C7C1A368474C20A615B25D2B204D0B0962D",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rfwYTifqaehhboCq6CW66RQ74bXCQESp9P",
+              "Flags": 4,
+              "MPTAmount": "499900",
+              "MPTokenIssuanceID": "00003F6375D00DFDB36367033BB1A4290476D06B211C5028",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "5E4F31456C3C2D7224B13E8A8E8EE036995AE092F700AACC35D23D036AE1A1BB",
+            "PreviousFields": {
+              "MPTAmount": "500000"
+            },
+            "PreviousTxnID": "56E9D10984920D5FB89E5E349D73E3D534BF2AD3A67E86F46B4B530C3ADD9BA5",
+            "PreviousTxnLgrSeq": 16235
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "AMMID": "0381DD891E64EEFBA1222773C1D2A806E3F5C592F9408A859D902FC39E3BD458",
+              "Account": "rfwYTifqaehhboCq6CW66RQ74bXCQESp9P",
+              "Balance": "100020005",
+              "Flags": 26214400,
+              "OwnerCount": 0,
+              "Sequence": 0
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "9B2F637B7CF255108030B90065E2A478578D5AE8C0493D3B5B5BB4642CA01C81",
+            "PreviousFields": {
+              "Balance": "100000000"
+            },
+            "PreviousTxnID": "56E9D10984920D5FB89E5E349D73E3D534BF2AD3A67E86F46B4B530C3ADD9BA5",
+            "PreviousTxnLgrSeq": 16235
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rU3ovNwQLBDocSsW4cS71szfCmjkF8eTZr",
+              "Balance": "999979971",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 16232
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "B5A0C132748290FE812B3BA4A610A343550876B0DB4219F76C154D3CA06E4EFA",
+            "PreviousFields": {
+              "Balance": "999999988",
+              "Sequence": 16231
+            },
+            "PreviousTxnID": "AEB28F21533AF17453F9B52A0D9FDD210C33E8D2E1C830573D7171AEEA82B2D0",
+            "PreviousTxnLgrSeq": 16233
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rU3ovNwQLBDocSsW4cS71szfCmjkF8eTZr",
+              "Flags": 0,
+              "MPTAmount": "100",
+              "MPTokenIssuanceID": "00003F6375D00DFDB36367033BB1A4290476D06B211C5028",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "DC8ED2D18B8B8EB5A123763AC88AF12E490A3F3936E9CAEE8D565DF5EF6D9198",
+            "PreviousFields": {},
+            "PreviousTxnID": "AEB28F21533AF17453F9B52A0D9FDD210C33E8D2E1C830573D7171AEEA82B2D0",
+            "PreviousTxnLgrSeq": 16233
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": [
+    {
+      "hash": "41809FF2487C77B0FD1E358323B71C7C1A368474C20A615B25D2B204D0B0962D",
+      "maker": "rfwYTifqaehhboCq6CW66RQ74bXCQESp9P",
+      "taker": "rU3ovNwQLBDocSsW4cS71szfCmjkF8eTZr",
+      "amm": "0381DD891E64EEFBA1222773C1D2A806E3F5C592F9408A859D902FC39E3BD458",
+      "takerPaid": {
+        "currency": "XRP",
+        "value": "0.020005"
+      },
+      "takerGot": {
+        "mpt_issuance_id": "00003F6375D00DFDB36367033BB1A4290476D06B211C5028",
+        "value": "100"
+      }
+    }
+  ]
+}

--- a/tests/txmeta/fixtures/mpt-xrp-amm-withdraw.json
+++ b/tests/txmeta/fixtures/mpt-xrp-amm-withdraw.json
@@ -1,0 +1,189 @@
+{
+  "description": "MPT/XRP AMM withdraw (no trade): Bob withdraws LP tokens from AMM pool. 0 exchanges.",
+  "tx": {
+    "Account": "rUX7KVnt4MocYuR43h9NheEhjxNtguThT5",
+    "Asset": {
+      "mpt_issuance_id": "000068131067BCD7C22517DFE865E938AB1DF668A546B22D"
+    },
+    "Asset2": {
+      "currency": "XRP"
+    },
+    "Fee": "12",
+    "Flags": 65536,
+    "LPTokenIn": {
+      "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+      "issuer": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+      "value": "50000"
+    },
+    "LastLedgerSequence": 26672,
+    "Sequence": 26647,
+    "SigningPubKey": "EDD0E1FCA9C64030EB6479672888491FD3F87D1A16C603871BBE162FEA821B0130",
+    "TransactionType": "AMMWithdraw",
+    "TxnSignature": "7730216683C77CAAE813068334EF08865EA7603D64550755DEFB7BE9386B279B9E3F0701867E8A3A3F1EEDACA136C51586A3420DD4E336E90BB13D8824C97800",
+    "hash": "29A0F14038593B11DC99FE33288E3C16C1B88078A1B053B4A291DEBFFF2D972E",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "AMMID": "0BD398A9BCA45003AAE646AE305558BE82A4FA394FB14E4FEBF5CD66D07C9CA4",
+              "Account": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+              "Balance": "109292894",
+              "Flags": 26214400,
+              "OwnerCount": 0,
+              "Sequence": 0
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "017058D3E442FEF8D68892573BA81A2BBAC541BDBD7455DB4062360E826ACCD3",
+            "PreviousFields": {
+              "Balance": "110000000"
+            },
+            "PreviousTxnID": "F7D08E7E743FFD6181C9D034E6C303D35F9B795322DBE3EFEA6BE40FD4BEF8AC",
+            "PreviousTxnLgrSeq": 26652
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+              "Asset": {
+                "mpt_issuance_id": "000068131067BCD7C22517DFE865E938AB1DF668A546B22D"
+              },
+              "Asset2": {
+                "currency": "XRP"
+              },
+              "AuctionSlot": {
+                "Account": "rDevP6bzEcCMiMB2qJwzNWhhzbrVU1EAa2",
+                "Expiration": 829780917,
+                "Price": {
+                  "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                  "issuer": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+                  "value": "0"
+                }
+              },
+              "Flags": 0,
+              "LPTokenBalance": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+                "value": "7728174.593052022"
+              },
+              "OwnerNode": "0",
+              "VoteSlots": [
+                {
+                  "VoteEntry": {
+                    "Account": "rDevP6bzEcCMiMB2qJwzNWhhzbrVU1EAa2",
+                    "VoteWeight": 100000
+                  }
+                }
+              ]
+            },
+            "LedgerEntryType": "AMM",
+            "LedgerIndex": "0BD398A9BCA45003AAE646AE305558BE82A4FA394FB14E4FEBF5CD66D07C9CA4",
+            "PreviousFields": {
+              "LPTokenBalance": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+                "value": "7778174.593052022"
+              }
+            },
+            "PreviousTxnID": "F7D08E7E743FFD6181C9D034E6C303D35F9B795322DBE3EFEA6BE40FD4BEF8AC",
+            "PreviousTxnLgrSeq": 26652
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rUX7KVnt4MocYuR43h9NheEhjxNtguThT5",
+              "Balance": "990707070",
+              "Flags": 0,
+              "OwnerCount": 2,
+              "Sequence": 26648
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "39C3BF20ABED593EEAA83F83850B7CA9C10F51E5AF93ECCB712CD6B504D17CA9",
+            "PreviousFields": {
+              "Balance": "989999976",
+              "Sequence": 26647
+            },
+            "PreviousTxnID": "F7D08E7E743FFD6181C9D034E6C303D35F9B795322DBE3EFEA6BE40FD4BEF8AC",
+            "PreviousTxnLgrSeq": 26652
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Balance": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "657106.781186547"
+              },
+              "Flags": 1114112,
+              "HighLimit": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+                "value": "0"
+              },
+              "HighNode": "0",
+              "LowLimit": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rUX7KVnt4MocYuR43h9NheEhjxNtguThT5",
+                "value": "0"
+              },
+              "LowNode": "0"
+            },
+            "LedgerEntryType": "RippleState",
+            "LedgerIndex": "CD89783E718E1D477DFA0808AE244B6D7281FF0B07DD53BD3FA9DEFD4499B5D1",
+            "PreviousFields": {
+              "Balance": {
+                "currency": "03F077DA9F26945991C0C4F286E18B3AD48008D7",
+                "issuer": "rrrrrrrrrrrrrrrrrrrrBZbvji",
+                "value": "707106.781186547"
+              }
+            },
+            "PreviousTxnID": "F7D08E7E743FFD6181C9D034E6C303D35F9B795322DBE3EFEA6BE40FD4BEF8AC",
+            "PreviousTxnLgrSeq": 26652
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rUX7KVnt4MocYuR43h9NheEhjxNtguThT5",
+              "Flags": 0,
+              "MPTAmount": "953535",
+              "MPTokenIssuanceID": "000068131067BCD7C22517DFE865E938AB1DF668A546B22D",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "D57584A8104514C1D32D5D0F281E8662464C121E2404F4A353E5DA9A63ACC838",
+            "PreviousFields": {
+              "MPTAmount": "950000"
+            },
+            "PreviousTxnID": "F7D08E7E743FFD6181C9D034E6C303D35F9B795322DBE3EFEA6BE40FD4BEF8AC",
+            "PreviousTxnLgrSeq": 26652
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rDyqVFHB4Kd4mXN1sJD9u3kZXAbCvRkhah",
+              "Flags": 4,
+              "MPTAmount": "546465",
+              "MPTokenIssuanceID": "000068131067BCD7C22517DFE865E938AB1DF668A546B22D",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "E3B885205505E03CDF774EA04842A48778BBD53CC40170D4FE74C88CCD205B8C",
+            "PreviousFields": {
+              "MPTAmount": "550000"
+            },
+            "PreviousTxnID": "F7D08E7E743FFD6181C9D034E6C303D35F9B795322DBE3EFEA6BE40FD4BEF8AC",
+            "PreviousTxnLgrSeq": 26652
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": []
+}

--- a/tests/txmeta/fixtures/mpt-xrp-multi-offer.json
+++ b/tests/txmeta/fixtures/mpt-xrp-multi-offer.json
@@ -1,0 +1,262 @@
+{
+  "description": "MPT/XRP multiple offer consumption: 2 offers crossed in one tx",
+  "tx": {
+    "Account": "rUYH3x62cwkigidkHEN8UzNdGCcS8xSLi3",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 30101,
+    "Sequence": 30074,
+    "SigningPubKey": "ED95AA9EE15B68C0DF61102A1D37EE5CB1AB6B525B9C3AAE29A2050A2C711CB699",
+    "TakerGets": "50000000",
+    "TakerPays": {
+      "mpt_issuance_id": "000075767A46F0002541282954B582540C405E76AC464856",
+      "value": "100"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "C9477288580683B2C7366D9A1D42426097E29F5DB9B806D5752A3C6C24570FC57F0977553D06F715660FDA06A44AFC37A5BF0DC9EF5EBA20ED5529E9907F3108",
+    "hash": "F942B4699F8FD806C7C8025BDE7F5383EBA19DE0D93BD1902B9C1721C372C70E",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rGNodcrMsaftzL18HbGxiXgGZNM5psrunQ",
+              "Balance": "424999976",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 30074
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "0459D7EB8F62F4F4004DD138C0ACF68AA279A28127DE18056526632543ADE277",
+            "PreviousFields": {
+              "Balance": "399999976",
+              "OwnerCount": 2
+            },
+            "PreviousTxnID": "F46605A78B33D1DAC451D8CE53A442940B6E4B6931692C485E31B0D4837B41B0",
+            "PreviousTxnLgrSeq": 30081
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rUYH3x62cwkigidkHEN8UzNdGCcS8xSLi3",
+              "Balance": "349999976",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 30075
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "130FE3281BC889D48E727C94FBD82C14705355A1CA609977109E5D64998078B7",
+            "PreviousFields": {
+              "Balance": "399999988",
+              "Sequence": 30074
+            },
+            "PreviousTxnID": "AEDFE5C3DB9082B1096C22B579C7F30046D39AE2582DB15986DC08D271C03755",
+            "PreviousTxnLgrSeq": 30077
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rLcbbZzrEdf6BQoonNkpQJzkABuCc6khco",
+              "RootIndex": "3EAD1CF994E52C1ECD7429F1CF4F2308211D42F7010D65CD401C239775775C34"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "3EAD1CF994E52C1ECD7429F1CF4F2308211D42F7010D65CD401C239775775C34",
+            "PreviousTxnID": "9C3DC221AB6F0D3537D30F45ECEE33BA66264B5A46DFB91C7A433C70FA6C315B",
+            "PreviousTxnLgrSeq": 30080
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rGNodcrMsaftzL18HbGxiXgGZNM5psrunQ",
+              "Flags": 0,
+              "MPTAmount": "950",
+              "MPTokenIssuanceID": "000075767A46F0002541282954B582540C405E76AC464856",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "5F372CF3E19E894951FE789B74BDD4EDCCF34FBBFB2C33A263E25E6A0A732A26",
+            "PreviousFields": {
+              "MPTAmount": "1000"
+            },
+            "PreviousTxnID": "29E20745BBAA084D5D43616049922FE7F7260C947FA178ACA775ACBF22C15758",
+            "PreviousTxnLgrSeq": 30079
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "ExchangeRate": "5a11c37937e08000",
+              "Flags": 0,
+              "PreviousTxnID": "F46605A78B33D1DAC451D8CE53A442940B6E4B6931692C485E31B0D4837B41B0",
+              "PreviousTxnLgrSeq": 30081,
+              "RootIndex": "675C8CEE6F5A1D8882FDD26B1E692D331827E738A59EE64B5A11C37937E08000",
+              "TakerGetsMPT": "000075767A46F0002541282954B582540C405E76AC464856",
+              "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+              "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "675C8CEE6F5A1D8882FDD26B1E692D331827E738A59EE64B5A11C37937E08000"
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "Account": "rGNodcrMsaftzL18HbGxiXgGZNM5psrunQ",
+              "BookDirectory": "675C8CEE6F5A1D8882FDD26B1E692D331827E738A59EE64B5A11C37937E08000",
+              "BookNode": "0",
+              "Flags": 0,
+              "OwnerNode": "0",
+              "PreviousTxnID": "F46605A78B33D1DAC451D8CE53A442940B6E4B6931692C485E31B0D4837B41B0",
+              "PreviousTxnLgrSeq": 30081,
+              "Sequence": 30073,
+              "TakerGets": {
+                "mpt_issuance_id": "000075767A46F0002541282954B582540C405E76AC464856",
+                "value": "0"
+              },
+              "TakerPays": "0"
+            },
+            "LedgerEntryType": "Offer",
+            "LedgerIndex": "897DACAAC4CBC6CAB2E568EA5E8DFD58EB7F94642655C6290FF12376FFF33FE2",
+            "PreviousFields": {
+              "TakerGets": {
+                "mpt_issuance_id": "000075767A46F0002541282954B582540C405E76AC464856",
+                "value": "50"
+              },
+              "TakerPays": "25000000"
+            }
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "Account": "rLcbbZzrEdf6BQoonNkpQJzkABuCc6khco",
+              "BookDirectory": "675C8CEE6F5A1D8882FDD26B1E692D331827E738A59EE64B5A11C37937E08000",
+              "BookNode": "0",
+              "Flags": 0,
+              "OwnerNode": "0",
+              "PreviousTxnID": "9C3DC221AB6F0D3537D30F45ECEE33BA66264B5A46DFB91C7A433C70FA6C315B",
+              "PreviousTxnLgrSeq": 30080,
+              "Sequence": 30072,
+              "TakerGets": {
+                "mpt_issuance_id": "000075767A46F0002541282954B582540C405E76AC464856",
+                "value": "0"
+              },
+              "TakerPays": "0"
+            },
+            "LedgerEntryType": "Offer",
+            "LedgerIndex": "8A625AE3057E489B9A042684C14C922F048B7F2E92E2881A8B8906F6C9DD9084",
+            "PreviousFields": {
+              "TakerGets": {
+                "mpt_issuance_id": "000075767A46F0002541282954B582540C405E76AC464856",
+                "value": "50"
+              },
+              "TakerPays": "25000000"
+            }
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rLcbbZzrEdf6BQoonNkpQJzkABuCc6khco",
+              "Balance": "424999976",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 30073
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "9AE3D66574FA0D4A1C6CF668668AB88BE2AE7CC36EFF8717B6E176CA987A59EF",
+            "PreviousFields": {
+              "Balance": "399999976",
+              "OwnerCount": 2
+            },
+            "PreviousTxnID": "9C3DC221AB6F0D3537D30F45ECEE33BA66264B5A46DFB91C7A433C70FA6C315B",
+            "PreviousTxnLgrSeq": 30080
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rUYH3x62cwkigidkHEN8UzNdGCcS8xSLi3",
+              "Flags": 0,
+              "MPTAmount": "100",
+              "MPTokenIssuanceID": "000075767A46F0002541282954B582540C405E76AC464856",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "9DDA1D5AED2A03ABC87332C2958440A21D9C3356057F949D0803EAC15D17FDCB",
+            "PreviousFields": {},
+            "PreviousTxnID": "AEDFE5C3DB9082B1096C22B579C7F30046D39AE2582DB15986DC08D271C03755",
+            "PreviousTxnLgrSeq": 30077
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rLcbbZzrEdf6BQoonNkpQJzkABuCc6khco",
+              "Flags": 0,
+              "MPTAmount": "950",
+              "MPTokenIssuanceID": "000075767A46F0002541282954B582540C405E76AC464856",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "AEE343314ECC00B57D2FB26B29D62E9A2FD42858FECAB93D7D8305DBD47CF22E",
+            "PreviousFields": {
+              "MPTAmount": "1000"
+            },
+            "PreviousTxnID": "884D9BDB27C8F6B4EE67E892532FC4F59EFDCEF581503341EF0D5EFEA1105291",
+            "PreviousTxnLgrSeq": 30078
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rGNodcrMsaftzL18HbGxiXgGZNM5psrunQ",
+              "RootIndex": "B9ACD1D195F1BC27FED1ACF6D8382B17CFE55B996BFBACDB07866AE98809DB9F"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "B9ACD1D195F1BC27FED1ACF6D8382B17CFE55B996BFBACDB07866AE98809DB9F",
+            "PreviousTxnID": "F46605A78B33D1DAC451D8CE53A442940B6E4B6931692C485E31B0D4837B41B0",
+            "PreviousTxnLgrSeq": 30081
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": [
+    {
+      "hash": "F942B4699F8FD806C7C8025BDE7F5383EBA19DE0D93BD1902B9C1721C372C70E",
+      "maker": "rGNodcrMsaftzL18HbGxiXgGZNM5psrunQ",
+      "taker": "rUYH3x62cwkigidkHEN8UzNdGCcS8xSLi3",
+      "sequence": 30073,
+      "takerPaid": {
+        "currency": "XRP",
+        "value": "25"
+      },
+      "takerGot": {
+        "mpt_issuance_id": "000075767A46F0002541282954B582540C405E76AC464856",
+        "value": "50"
+      }
+    },
+    {
+      "hash": "F942B4699F8FD806C7C8025BDE7F5383EBA19DE0D93BD1902B9C1721C372C70E",
+      "maker": "rLcbbZzrEdf6BQoonNkpQJzkABuCc6khco",
+      "taker": "rUYH3x62cwkigidkHEN8UzNdGCcS8xSLi3",
+      "sequence": 30072,
+      "takerPaid": {
+        "currency": "XRP",
+        "value": "25"
+      },
+      "takerGot": {
+        "mpt_issuance_id": "000075767A46F0002541282954B582540C405E76AC464856",
+        "value": "50"
+      }
+    }
+  ]
+}

--- a/tests/txmeta/fixtures/mpt-xrp-offer-plus-amm.json
+++ b/tests/txmeta/fixtures/mpt-xrp-offer-plus-amm.json
@@ -1,0 +1,220 @@
+{
+  "description": "MPT/XRP combined offer + AMM: 1000 raw MPT via offer + 100 raw MPT via AMM",
+  "tx": {
+    "Account": "rMuP2jYqMGWn59xY61fNcNryP2hbLVVBud",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 31140,
+    "Sequence": 31113,
+    "SigningPubKey": "EDD161459F6414F6CEB19BB2BB77AFF29F25EC685DAD6A79AD43FC9951E82AE94C",
+    "TakerGets": "100000000",
+    "TakerPays": {
+      "mpt_issuance_id": "00007985710390B104077C8D426E3922E378DFED2B24711C",
+      "value": "1100"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "18B9914B06A111E1BFA745AE3CFA9808329C6F4F42B56ABEBA1AB4A1656CAA37BB07F3763B30FD6197DEAF15C32B929848346DE63C84EBE8C7290577EEC03805",
+    "hash": "A513A9E32D41E9D016981FA8ECA64256DBEA680136952BD5732647158BBD45E5",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "AMMID": "B017ADCC62E99D0DF3A0B76BEEF3836AB1CD0E9D91E17A387399C5D854DDC0B7",
+              "Account": "r3SST8ZRE1dhU15ibhCfoJPyxAxF74448E",
+              "Balance": "100020005",
+              "Flags": 26214400,
+              "OwnerCount": 0,
+              "Sequence": 0
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "181D7CB2FFD93FE0021F68FCBEDA86CDC73F14A7B21172BB2B22F9D94A6CF6D5",
+            "PreviousFields": {
+              "Balance": "100000000"
+            },
+            "PreviousTxnID": "4934D5BDCFBD52578F704D28B4C0ED71F6D977FD229F8EFCA0331551FC50C203",
+            "PreviousTxnLgrSeq": 31120
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rBHWsB9LjJ51iMD59NZcGUsvGmr9jfrLTH",
+              "Flags": 0,
+              "MPTokenIssuanceID": "00007985710390B104077C8D426E3922E378DFED2B24711C",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "5C9FAA1967DCB0B6C265E3FED9014FDE48CB35CF2F1F56B52BE3AD8B61F0F8DB",
+            "PreviousFields": {
+              "MPTAmount": "1000"
+            },
+            "PreviousTxnID": "AA06FDFF801CFEBA227F4D8C3B6D87828C0A307A677BA30339AF4CDE0069970C",
+            "PreviousTxnLgrSeq": 31117
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "r3SST8ZRE1dhU15ibhCfoJPyxAxF74448E",
+              "Flags": 4,
+              "MPTAmount": "499900",
+              "MPTokenIssuanceID": "00007985710390B104077C8D426E3922E378DFED2B24711C",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "918C969A3801F99E530112A2E5FB4FB64510129BB26CC61B16CD041618337EDC",
+            "PreviousFields": {
+              "MPTAmount": "500000"
+            },
+            "PreviousTxnID": "4934D5BDCFBD52578F704D28B4C0ED71F6D977FD229F8EFCA0331551FC50C203",
+            "PreviousTxnLgrSeq": 31120
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rBHWsB9LjJ51iMD59NZcGUsvGmr9jfrLTH",
+              "Balance": "1000099976",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 31112
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "973E1A9667286FA318BFEA67EC909880EBF63CE5DAF252077CE82ABD61E57C01",
+            "PreviousFields": {
+              "Balance": "999999976",
+              "OwnerCount": 2
+            },
+            "PreviousTxnID": "CEDCA7310C35C1156394D12A2AE689027422AB54503610F0904B41315B5E2E6A",
+            "PreviousTxnLgrSeq": 31119
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "Account": "rBHWsB9LjJ51iMD59NZcGUsvGmr9jfrLTH",
+              "BookDirectory": "DE302B813B3737FDE5BACF7904C8455823D80A15561B134957038D7EA4C68000",
+              "BookNode": "0",
+              "Flags": 0,
+              "OwnerNode": "0",
+              "PreviousTxnID": "CEDCA7310C35C1156394D12A2AE689027422AB54503610F0904B41315B5E2E6A",
+              "PreviousTxnLgrSeq": 31119,
+              "Sequence": 31111,
+              "TakerGets": {
+                "mpt_issuance_id": "00007985710390B104077C8D426E3922E378DFED2B24711C",
+                "value": "0"
+              },
+              "TakerPays": "0"
+            },
+            "LedgerEntryType": "Offer",
+            "LedgerIndex": "D4CF5CB01B5AB04B5F83F49E2AC5434F1C5399DA25244988247D2E7CDF97341B",
+            "PreviousFields": {
+              "TakerGets": {
+                "mpt_issuance_id": "00007985710390B104077C8D426E3922E378DFED2B24711C",
+                "value": "1000"
+              },
+              "TakerPays": "100000"
+            }
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rBHWsB9LjJ51iMD59NZcGUsvGmr9jfrLTH",
+              "RootIndex": "D61C33C245C455BAB6FF78B51CA9EE49BAA2D797207B11086555391DD7504AED"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "D61C33C245C455BAB6FF78B51CA9EE49BAA2D797207B11086555391DD7504AED",
+            "PreviousTxnID": "CEDCA7310C35C1156394D12A2AE689027422AB54503610F0904B41315B5E2E6A",
+            "PreviousTxnLgrSeq": 31119
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rMuP2jYqMGWn59xY61fNcNryP2hbLVVBud",
+              "Flags": 0,
+              "MPTAmount": "1100",
+              "MPTokenIssuanceID": "00007985710390B104077C8D426E3922E378DFED2B24711C",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "DBF32B85792980A071639EC6220ED1E3D7036FDF0E7F3CA31709B9003C048D3B",
+            "PreviousFields": {},
+            "PreviousTxnID": "925AC6A35BEB3DB7C1C86B601C5879514F7A55204BBD51542E25C55DDC4281FF",
+            "PreviousTxnLgrSeq": 31116
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "ExchangeRate": "57038d7ea4c68000",
+              "Flags": 0,
+              "PreviousTxnID": "CEDCA7310C35C1156394D12A2AE689027422AB54503610F0904B41315B5E2E6A",
+              "PreviousTxnLgrSeq": 31119,
+              "RootIndex": "DE302B813B3737FDE5BACF7904C8455823D80A15561B134957038D7EA4C68000",
+              "TakerGetsMPT": "00007985710390B104077C8D426E3922E378DFED2B24711C",
+              "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+              "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "DE302B813B3737FDE5BACF7904C8455823D80A15561B134957038D7EA4C68000"
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rMuP2jYqMGWn59xY61fNcNryP2hbLVVBud",
+              "Balance": "999879971",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 31114
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "E93F35101B7B39595053ED23267333EB60CBC52AF8076CF942B599F7AD1FD3D6",
+            "PreviousFields": {
+              "Balance": "999999988",
+              "Sequence": 31113
+            },
+            "PreviousTxnID": "925AC6A35BEB3DB7C1C86B601C5879514F7A55204BBD51542E25C55DDC4281FF",
+            "PreviousTxnLgrSeq": 31116
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": [
+    {
+      "hash": "A513A9E32D41E9D016981FA8ECA64256DBEA680136952BD5732647158BBD45E5",
+      "maker": "rBHWsB9LjJ51iMD59NZcGUsvGmr9jfrLTH",
+      "taker": "rMuP2jYqMGWn59xY61fNcNryP2hbLVVBud",
+      "sequence": 31111,
+      "takerPaid": {
+        "currency": "XRP",
+        "value": "0.1"
+      },
+      "takerGot": {
+        "mpt_issuance_id": "00007985710390B104077C8D426E3922E378DFED2B24711C",
+        "value": "1000"
+      }
+    },
+    {
+      "hash": "A513A9E32D41E9D016981FA8ECA64256DBEA680136952BD5732647158BBD45E5",
+      "maker": "r3SST8ZRE1dhU15ibhCfoJPyxAxF74448E",
+      "taker": "rMuP2jYqMGWn59xY61fNcNryP2hbLVVBud",
+      "amm": "B017ADCC62E99D0DF3A0B76BEEF3836AB1CD0E9D91E17A387399C5D854DDC0B7",
+      "takerPaid": {
+        "currency": "XRP",
+        "value": "0.020005"
+      },
+      "takerGot": {
+        "mpt_issuance_id": "00007985710390B104077C8D426E3922E378DFED2B24711C",
+        "value": "100"
+      }
+    }
+  ]
+}

--- a/tests/txmeta/fixtures/mpt-xrp-offer.json
+++ b/tests/txmeta/fixtures/mpt-xrp-offer.json
@@ -1,0 +1,170 @@
+{
+  "description": "MPT/XRP exact offer match: 50 XRP for 500 raw MPT",
+  "tx": {
+    "Account": "rfL1B36NyY1jcvk5wC8EwZkfKo2ctFkbVn",
+    "Fee": "12",
+    "Flags": 0,
+    "LastLedgerSequence": 13332,
+    "Sequence": 13308,
+    "SigningPubKey": "EDA86007E4CB738D3D190FB2472CF392349BB0291FF2C682BBD38A090F4DD3F270",
+    "TakerGets": "50000000",
+    "TakerPays": {
+      "mpt_issuance_id": "000033F94D8ABB5A839DBAF33DE222BF3D1D211AE4BF0D2C",
+      "value": "500"
+    },
+    "TransactionType": "OfferCreate",
+    "TxnSignature": "8663CBC5EF2CEA54C4D8EA7C78DE079F4DAD9B4A42A4F0E178B4C6DC3F65F3BEC2C612755A9D8D5A25C8EC19ED5F22B4EAB9296DF16DA652F405E31597EE2D0F",
+    "hash": "82A56400901F19304EAD0B4CCB91261536C8284263CA9201AA8871D537D2AA3E",
+    "metaData": {
+      "AffectedNodes": [
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rfL1B36NyY1jcvk5wC8EwZkfKo2ctFkbVn",
+              "Flags": 0,
+              "MPTAmount": "500",
+              "MPTokenIssuanceID": "000033F94D8ABB5A839DBAF33DE222BF3D1D211AE4BF0D2C",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "3864DF620FB74195EB2D01493906457339F66B7B14F4123FB6562458D57193BB",
+            "PreviousFields": {},
+            "PreviousTxnID": "431085F420E79003514B4683E9F34C1EF3F742BE70B260A97C81AB22B6164250",
+            "PreviousTxnLgrSeq": 13310
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "ExchangeRate": "5a038d7ea4c68000",
+              "Flags": 0,
+              "PreviousTxnID": "ACCEEA26022C2DE1DAFF0C72656525D9501760CE4CA0D7D5D16A667E75CAE248",
+              "PreviousTxnLgrSeq": 13312,
+              "RootIndex": "56E112A7EDF93CF559592C4C787895E27756DE7C7C0BD2F35A038D7EA4C68000",
+              "TakerGetsMPT": "000033F94D8ABB5A839DBAF33DE222BF3D1D211AE4BF0D2C",
+              "TakerPaysCurrency": "0000000000000000000000000000000000000000",
+              "TakerPaysIssuer": "0000000000000000000000000000000000000000"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "56E112A7EDF93CF559592C4C787895E27756DE7C7C0BD2F35A038D7EA4C68000"
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rEJ2ruxBVypBms7VV5PHSVEygjTnpcxpQ9",
+              "Flags": 0,
+              "MPTAmount": "500",
+              "MPTokenIssuanceID": "000033F94D8ABB5A839DBAF33DE222BF3D1D211AE4BF0D2C",
+              "OwnerNode": "0"
+            },
+            "LedgerEntryType": "MPToken",
+            "LedgerIndex": "7AEF0291A52FE770CE16F07647A06A49097AE5A7A11E6772CFC66A0C3E8CF8DF",
+            "PreviousFields": {
+              "MPTAmount": "1000"
+            },
+            "PreviousTxnID": "E7B4349F0871BC3C2D80D1EB3D65FC2D4EA2406B238318DF54FE5659F4E49DFA",
+            "PreviousTxnLgrSeq": 13311
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rEJ2ruxBVypBms7VV5PHSVEygjTnpcxpQ9",
+              "Balance": "449999976",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 13308
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "8190DF3997EBFB3104E73013F959651A40F33BDEEA23DBCC031E40EFCE75DB2D",
+            "PreviousFields": {
+              "Balance": "399999976",
+              "OwnerCount": 2
+            },
+            "PreviousTxnID": "ACCEEA26022C2DE1DAFF0C72656525D9501760CE4CA0D7D5D16A667E75CAE248",
+            "PreviousTxnLgrSeq": 13312
+          }
+        },
+        {
+          "DeletedNode": {
+            "FinalFields": {
+              "Account": "rEJ2ruxBVypBms7VV5PHSVEygjTnpcxpQ9",
+              "BookDirectory": "56E112A7EDF93CF559592C4C787895E27756DE7C7C0BD2F35A038D7EA4C68000",
+              "BookNode": "0",
+              "Flags": 0,
+              "OwnerNode": "0",
+              "PreviousTxnID": "ACCEEA26022C2DE1DAFF0C72656525D9501760CE4CA0D7D5D16A667E75CAE248",
+              "PreviousTxnLgrSeq": 13312,
+              "Sequence": 13307,
+              "TakerGets": {
+                "mpt_issuance_id": "000033F94D8ABB5A839DBAF33DE222BF3D1D211AE4BF0D2C",
+                "value": "0"
+              },
+              "TakerPays": "0"
+            },
+            "LedgerEntryType": "Offer",
+            "LedgerIndex": "90A44BA780F28513D972D496F688A2283894237631A2F3479E16DAF6AB430A21",
+            "PreviousFields": {
+              "TakerGets": {
+                "mpt_issuance_id": "000033F94D8ABB5A839DBAF33DE222BF3D1D211AE4BF0D2C",
+                "value": "500"
+              },
+              "TakerPays": "50000000"
+            }
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Account": "rfL1B36NyY1jcvk5wC8EwZkfKo2ctFkbVn",
+              "Balance": "349999976",
+              "Flags": 0,
+              "OwnerCount": 1,
+              "Sequence": 13309
+            },
+            "LedgerEntryType": "AccountRoot",
+            "LedgerIndex": "D607739FA5627BAFEF7DECD2F513D7A2857AE94BAB47B289AB46A4DBE567FB48",
+            "PreviousFields": {
+              "Balance": "399999988",
+              "Sequence": 13308
+            },
+            "PreviousTxnID": "431085F420E79003514B4683E9F34C1EF3F742BE70B260A97C81AB22B6164250",
+            "PreviousTxnLgrSeq": 13310
+          }
+        },
+        {
+          "ModifiedNode": {
+            "FinalFields": {
+              "Flags": 0,
+              "Owner": "rEJ2ruxBVypBms7VV5PHSVEygjTnpcxpQ9",
+              "RootIndex": "E9373625C8318C83A7E9A64DE029D8E443BDC9B083D6485422F763C60BF9125A"
+            },
+            "LedgerEntryType": "DirectoryNode",
+            "LedgerIndex": "E9373625C8318C83A7E9A64DE029D8E443BDC9B083D6485422F763C60BF9125A",
+            "PreviousTxnID": "ACCEEA26022C2DE1DAFF0C72656525D9501760CE4CA0D7D5D16A667E75CAE248",
+            "PreviousTxnLgrSeq": 13312
+          }
+        }
+      ],
+      "TransactionIndex": 0,
+      "TransactionResult": "tesSUCCESS"
+    }
+  },
+  "expected": [
+    {
+      "hash": "82A56400901F19304EAD0B4CCB91261536C8284263CA9201AA8871D537D2AA3E",
+      "maker": "rEJ2ruxBVypBms7VV5PHSVEygjTnpcxpQ9",
+      "taker": "rfL1B36NyY1jcvk5wC8EwZkfKo2ctFkbVn",
+      "sequence": 13307,
+      "takerPaid": {
+        "currency": "XRP",
+        "value": "50"
+      },
+      "takerGot": {
+        "mpt_issuance_id": "000033F94D8ABB5A839DBAF33DE222BF3D1D211AE4BF0D2C",
+        "value": "500"
+      }
+    }
+  ]
+}

--- a/tests/txmeta/txmeta.test.js
+++ b/tests/txmeta/txmeta.test.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { extractExchanges } from '@xrplkit/txmeta'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const fixtureDir = path.join(__dirname, 'fixtures')
+
+const fixtures = fs.readdirSync(fixtureDir)
+	.filter(f => f.endsWith('.json'))
+	.map(f => JSON.parse(fs.readFileSync(path.join(fixtureDir, f), 'utf-8')))
+
+
+describe('extractExchanges', () => {
+	for (let { description, tx, expected } of fixtures) {
+		it(description, () => {
+			let exchanges = extractExchanges(tx)
+
+			expect(exchanges).to.have.length(expected.length)
+
+			for (let i = 0; i < expected.length; i++) {
+				expect(exchanges[i]).to.deep.equal(expected[i])
+			}
+		})
+	}
+})

--- a/tokens/amount.js
+++ b/tokens/amount.js
@@ -11,7 +11,13 @@ export function amountFromRippled(amount, decodeCurrency){
 			currency: 'XRP',
 			value: div(amount, '1000000')
 		}
-	
+
+	if(amount.mpt_issuance_id)
+		return {
+			mpt_issuance_id: amount.mpt_issuance_id,
+			value: XFL(amount.value)
+		}
+
 	return {
 		currency: decodeCurrency
 			? currencyHexToUTF8(amount.currency)
@@ -28,7 +34,13 @@ export function amountToRippled(amount){
 
 	if(amount.currency === 'XRP')
 		return floor(mul(amount.value, '1000000')).toString()
-		
+
+	if(amount.mpt_issuance_id)
+		return {
+			mpt_issuance_id: amount.mpt_issuance_id,
+			value: amount.value.toString()
+		}
+
 	return {
 		currency: currencyUTF8ToHex(amount.currency),
 		issuer: amount.issuer,
@@ -39,6 +51,11 @@ export function amountToRippled(amount){
 export function tokenFromAmount(amount){
 	if(amount === undefined)
 		return undefined
+
+	if(amount.mpt_issuance_id)
+		return {
+			mpt_issuance_id: amount.mpt_issuance_id
+		}
 
 	return {
 		currency: amount.currency,

--- a/tokens/comparison.js
+++ b/tokens/comparison.js
@@ -3,19 +3,26 @@ import { currencyUTF8ToHex } from './currency.js'
 export function isSameToken(a, b){
 	if(typeof a === 'string')
 		a = {currency: 'XRP'}
+	else if(a.mpt_issuance_id)
+		a = { mpt_issuance_id: a.mpt_issuance_id }
 	else
 		a = {
-			currency: currencyUTF8ToHex(a.currency), 
+			currency: currencyUTF8ToHex(a.currency),
 			issuer: a.issuer || a.account
 		}
 
 	if(typeof b === 'string')
 		b = {currency: 'XRP'}
+	else if(b.mpt_issuance_id)
+		b = { mpt_issuance_id: b.mpt_issuance_id }
 	else
 		b = {
-			currency: currencyUTF8ToHex(b.currency), 
+			currency: currencyUTF8ToHex(b.currency),
 			issuer: b.issuer || a.account
 		}
+
+	if(a.mpt_issuance_id || b.mpt_issuance_id)
+		return a.mpt_issuance_id === b.mpt_issuance_id
 
 	return true
 		&& a.currency === b.currency

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -6,6 +6,6 @@
     "license": "ISC",
     "author": "xrplkit",
     "dependencies": {
-        "@xrplkit/xfl": "file:../xfl"
+        "@xrplkit/xfl": "2.1.2"
     }
 }

--- a/tokens/package.json
+++ b/tokens/package.json
@@ -6,6 +6,6 @@
     "license": "ISC",
     "author": "xrplkit",
     "dependencies": {
-        "@xrplkit/xfl": "2.1.2"
+        "@xrplkit/xfl": "file:../xfl"
     }
 }

--- a/txmeta/extract.js
+++ b/txmeta/extract.js
@@ -46,21 +46,46 @@ export function extractExchanges(tx, options={}){
 	for(let { FinalFields, PreviousFields } of affectedAMMs){
 		let maker = FinalFields.Account
 		let amm = FinalFields.AMMID
+		let token
+		let delta
+
+		let xrpDelta = div(sub(FinalFields.Balance, PreviousFields.Balance), '1000000')
+
+		// Check for IOU side (RippleState)
 		let rippleState = affectedNodes
 			.filter(node => node.LedgerEntryType === 'RippleState')
-			.find(node => node.FinalFields.HighLimit.issuer === maker || node.FinalFields.LowLimit.issuer === maker)
+			.find(node => node.PreviousFields
+				&& (node.FinalFields.HighLimit.issuer === maker || node.FinalFields.LowLimit.issuer === maker))
 
-		if(!rippleState || !rippleState.PreviousFields)
+		if(rippleState){
+			let fields = rippleState.FinalFields
+			delta = sub(abs(fields.Balance.value), abs(rippleState.PreviousFields.Balance.value))
+			let iouToken = fields.HighLimit.issuer === maker
+				? fields.LowLimit
+				: fields.HighLimit
+
+			token = { currency: iouToken.currency, issuer: iouToken.issuer }
+		}
+
+		// Check for MPT side (MPToken)
+		if(!token){
+			let mptoken = affectedNodes
+				.filter(node => node.LedgerEntryType === 'MPToken')
+				.find(node => node.FinalFields.Account === maker)
+
+			if(mptoken){
+				let fields = mptoken.FinalFields
+				let previousAmount = mptoken.PreviousFields?.MPTAmount || '0'
+				delta = sub(fields.MPTAmount || '0', previousAmount)
+				token = { mpt_issuance_id: fields.MPTokenIssuanceID }
+			}
+		}
+
+		if(!token)
 			continue
 
 		let takerPaid
 		let takerGot
-
-		let xrpDelta = div(sub(FinalFields.Balance, PreviousFields.Balance), '1000000')
-		let iouDelta = sub(abs(rippleState.FinalFields.Balance.value), abs(rippleState.PreviousFields.Balance.value))
-		let iouToken = rippleState.FinalFields.HighLimit.issuer === maker
-			? rippleState.FinalFields.LowLimit
-			: rippleState.FinalFields.HighLimit
 
 		if(gt(xrpDelta, '0')){
 			takerPaid = {
@@ -68,20 +93,20 @@ export function extractExchanges(tx, options={}){
 				value: xrpDelta.toString()
 			}
 			takerGot = {
-				...iouToken,
-				value: abs(iouDelta).toString()
+				...token,
+				value: abs(delta).toString()
 			}
 		}else{
 			takerPaid = {
-				...iouToken,
-				value: iouDelta.toString()
+				...token,
+				value: delta.toString()
 			}
 			takerGot = {
 				currency: 'XRP',
 				value: abs(xrpDelta).toString()
 			}
 		}
-		
+
 		exchanges.push({
 			hash,
 			maker,

--- a/txmeta/extract.js
+++ b/txmeta/extract.js
@@ -39,9 +39,14 @@ export function extractExchanges(tx, options={}){
 		})
 	}
 
-	let affectedAMMs = affectedNodes
-		.filter(node => node.LedgerEntryType === 'AccountRoot')
-		.filter(node => node.FinalFields?.AMMID)
+	let txType = tx.TransactionType || tx.transaction?.TransactionType || tx.tx?.TransactionType
+	let isAMMLiquidityOperation = txType === 'AMMDeposit' || txType === 'AMMWithdraw'
+
+	let affectedAMMs = isAMMLiquidityOperation
+		? []
+		: affectedNodes
+			.filter(node => node.LedgerEntryType === 'AccountRoot')
+			.filter(node => node.FinalFields?.AMMID)
 
 	for(let { FinalFields, PreviousFields } of affectedAMMs){
 		let maker = FinalFields.Account
@@ -51,7 +56,7 @@ export function extractExchanges(tx, options={}){
 
 		let xrpDelta = div(sub(FinalFields.Balance, PreviousFields.Balance), '1000000')
 
-		// Check for IOU side (RippleState)
+		// XRP-IOU AMM pool consumption
 		let rippleState = affectedNodes
 			.filter(node => node.LedgerEntryType === 'RippleState')
 			.find(node => node.PreviousFields
@@ -67,7 +72,7 @@ export function extractExchanges(tx, options={}){
 			token = { currency: iouToken.currency, issuer: iouToken.issuer }
 		}
 
-		// Check for MPT side (MPToken)
+		// XRP-MPT AMM pool consumption
 		if(!token){
 			let mptoken = affectedNodes
 				.filter(node => node.LedgerEntryType === 'MPToken')

--- a/txmeta/package.json
+++ b/txmeta/package.json
@@ -4,7 +4,7 @@
     "version": "1.4.3",
     "main": "extract.js",
     "dependencies": {
-        "@xrplkit/xfl": "2.1.2",
-        "@xrplkit/tokens": "1.0.2"
+        "@xrplkit/xfl": "file:../xfl",
+        "@xrplkit/tokens": "file:../tokens"
     }
 }

--- a/txmeta/package.json
+++ b/txmeta/package.json
@@ -4,7 +4,7 @@
     "version": "1.4.3",
     "main": "extract.js",
     "dependencies": {
-        "@xrplkit/xfl": "file:../xfl",
-        "@xrplkit/tokens": "file:../tokens"
+        "@xrplkit/xfl": "2.1.2",
+        "@xrplkit/tokens": "1.0.2"
     }
 }


### PR DESCRIPTION
### Summary
- Add MPT amount support to `@xrplkit/tokens` (`amountFromRippled`, `amountToRippled`, `tokenFromAmount`, `isSameToken`)
- Add MPT exchange extraction to `@xrplkit/txmeta` (`extractExchanges`) for both DEX Offer and AMM trades
- Fix false exchange detection from `AMMDeposit` and `AMMWithdraw` transactions

### Tests
- Token tests (amountFromRippled, amountToRippled, tokenFromAmount, isSameToken — XRP, IOU, MPT)
- txmeta fixture tests from real ledger data:
  - 5 exact offer matches (IOU/XRP, IOU/IOU, IOU/MPT, MPT/XRP, MPT/MPT)
  - 2 AMM offer consumption (IOU/XRP, MPT/XRP)
  - 1 combined offer + AMM consumption (MPT/XRP)
  - 1 multi-offer consumption (MPT/XRP, 2 offers in 1 tx)
  - 3 AMM non-consumption (IOU/IOU, IOU/MPT, MPT/MPT — offers don't cross non-XRP AMMs)
  - 3 AMM deposit/withdraw (0 exchanges — liquidity operations)

### Packages to release:
- @xrplkit/tokens
- @xrplkit/txmeta